### PR TITLE
fix: handle gitignore line endings

### DIFF
--- a/src/helpers/config.js
+++ b/src/helpers/config.js
@@ -1,0 +1,31 @@
+const fs = require('fs-extra')
+const { EOL } = require('os')
+
+exports.spliceConfig = async function spliceConfig({
+  startMarker,
+  endMarker,
+  contents,
+  fileName,
+}) {
+  await fs.ensureFile(fileName)
+  const data = await fs.readFile(fileName, 'utf8')
+  const [initial = '', rest = ''] = data.split(startMarker)
+  const [inner, final = ''] = rest.split(endMarker)
+  const out = [
+    initial,
+    initial.endsWith(EOL) ? '' : EOL,
+    startMarker,
+    EOL,
+    contents,
+    EOL,
+    endMarker,
+    final.startsWith(EOL) ? '' : EOL,
+    final,
+  ]
+    .filter(Boolean)
+    .join('')
+
+  console.log({ out, data, initial, rest, inner, final })
+
+  return fs.writeFile(fileName, out)
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 const path = require('path')
 const fs = require('fs-extra')
+const { spliceConfig } = require('./helpers/config')
 
 const normalizedCacheDir = (PUBLISH_DIR) =>
   path.normalize(`${PUBLISH_DIR}/../.cache`)
@@ -62,12 +63,13 @@ module.exports = {
 
       // add gatsby functions to .gitignore if doesn't exist
       const gitignorePath = path.resolve('.gitignore')
-      const gitignoreString = `\r\n# netlify-plugin-gatsby ignores\r\n${FUNCTIONS_SRC}/gatsby\r\n`
-      const gitignoreContents = await fs.readFile(gitignorePath)
 
-      if (!gitignoreContents.includes(gitignoreString)) {
-        await fs.appendFile(path.resolve('.gitignore'), gitignoreString)
-      }
+      await spliceConfig({
+        startMarker: '# netlify-plugin-gatsby ignores start',
+        endMarker: '# netlify-plugin-gatsby ignores end',
+        contents: `${FUNCTIONS_SRC}/gatsby`,
+        fileName: gitignorePath,
+      })
     } catch (error) {
       utils.build.failBuild('Error message', { error })
     }
@@ -90,14 +92,12 @@ module.exports = {
 
       const redirectsPath = path.resolve(`${PUBLISH_DIR}/_redirects`)
 
-      // ensure we have a _redirects file
-      await fs.ensureFile(redirectsPath)
-
-      // add redirect to _redirects file
-      await fs.appendFile(
-        redirectsPath,
-        `\r\n# netlify-plugin-gatsby redirects\r\n/api/* /.netlify/functions/gatsby 200\r\n`,
-      )
+      await spliceConfig({
+        startMarker: '# netlify-plugin-gatsby redirects start',
+        endMarker: '# netlify-plugin-gatsby redirects end',
+        contents: '/api/* /.netlify/functions/gatsby 200',
+        fileName: redirectsPath,
+      })
     } catch (error) {
       utils.build.failBuild('Error message', { error })
     }

--- a/test/fixtures/functions-without-gatsby-plugin/.gitignore
+++ b/test/fixtures/functions-without-gatsby-plugin/.gitignore
@@ -9,5 +9,6 @@ public
 netlify/functions/gatsby/functions
 deployment.json
 
-# netlify-plugin-gatsby ignores
+# netlify-plugin-gatsby ignores start
 netlify/functions/gatsby
+# netlify-plugin-gatsby ignores end

--- a/test/fixtures/functions-without-gatsby-plugin/_redirects
+++ b/test/fixtures/functions-without-gatsby-plugin/_redirects
@@ -1,3 +1,0 @@
-
-# netlify-plugin-gatsby redirects
-/api/* /.netlify/functions/gatsby 200


### PR DESCRIPTION
Git normalizes line endings when checking files in and out. The current implementation generates a gitignore with CRLF. This is converted to LF when checked-in, which means that when we check on the next build it doesn't recognise that it has already been added, so generates a duplicate. This PR switches to a more robust system that uses a start and end marker and can handle different sorts of line ending