### PR TITLE
docs: adds Gatsby Cache note to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This build plugin is a utility for supporting Gatsby on Netlify. To support
 build caching and Gatsby functions on Netlify, you will need to install this
 plugin for your app.
 
-> **Note:** Essential Gatsby includes functionality from the [Gatsby cache build plugin](https://github.com/jlengstorf/netlify-plugin-gatsby-cache). If you already have the Gatsby cache plugin installed, you should [remove it](https://docs.netlify.com/configure-builds/build-plugins/#remove-a-plugin) before installing this plugin.
+> **Note:** Essential Gatsby includes functionality from the [Gatsby cache build plugin](https://github.com/jlengstorf/netlify-plugin-gatsby-cache). If you already have the Gatsby Cache plugin installed, you should [remove it](https://docs.netlify.com/configure-builds/build-plugins/#remove-a-plugin) before installing this plugin.
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ This build plugin is a utility for supporting Gatsby on Netlify. To support
 build caching and Gatsby functions on Netlify, you will need to install this
 plugin for your app.
 
-> **Note:** Essential Gatsby includes functionality from the [Gatsby cache build plugin](https://github.com/jlengstorf/netlify-plugin-gatsby-cache). If you already have the Gatsby Cache plugin installed, you should [remove it](https://docs.netlify.com/configure-builds/build-plugins/#remove-a-plugin) before installing this plugin.
+> **Note:** 
+> - Essential Gatsby includes functionality from the [Gatsby Cache build plugin](https://github.com/jlengstorf/netlify-plugin-gatsby-cache). If you already have the Gatsby Cache plugin installed on your Netlify site, you should [remove it](https://docs.netlify.com/configure-builds/build-plugins/#remove-a-plugin) before installing this plugin.
+> - Essential Gatsby is not compatible with the Gatsby community plugin [gatsby-plugin-netlify-cache](https://www.gatsbyjs.com/plugins/gatsby-plugin-netlify-cache/).
+
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This build plugin is a utility for supporting Gatsby on Netlify. To support
 build caching and Gatsby functions on Netlify, you will need to install this
 plugin for your app.
 
+> **Note:** Essential Gatsby includes functionality from the [Gatsby cache build plugin](https://github.com/jlengstorf/netlify-plugin-gatsby-cache). If you already have the Gatsby cache plugin installed, you should [remove it](https://docs.netlify.com/configure-builds/build-plugins/#remove-a-plugin) before installing this plugin.
+
 ## Table of Contents
 
 - [Installation and Configuration](#installation-and-configuration)


### PR DESCRIPTION
This docs PR adds a note to help users who may want to install this plugin manually but already have Gatsby Cache build plugin installed on their site.

For newly linked sites, this plugin would get installed first, so it's not really a concern.