### PR TITLE
fix(plugin-package-json): add bugs url

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -29,6 +29,9 @@
   "engines": {
     "node": ">=12.13.0"
   },
+  "bugs": {
+    "url": "https://github.com/netlify/netlify-plugin-gatsby/issues"
+  },
   "scripts": {
     "release": "release-it",
     "prepublishOnly": "cp ../README.md ."


### PR DESCRIPTION
This PR adds a `bugs` URL to the plugin's package.json

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have added tests (we are enforcing 100% test coverage).
- [x] I have added documentation in the `README.md`, the `docs` directory (if
      any) and the `examples` directory (if any).
- [x] The status checks are successful (continuous integration). Those can be
      seen below.
