### PR TITLE
fix: use offline build instead of fake token

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -13,7 +13,7 @@
     "build": "gatsby build",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
-    "build:netlify": "NETLIFY_AUTH_TOKEN=fake netlify build",
+    "build:netlify": "netlify build --offline",
     "preview": "netlify dev --offline",
     "test": "run-s build:netlify test:e2e",
     "test:e2e": "start-server-and-test preview 8888 test:jest",

--- a/plugin/test/fixtures/custom-functions-directory/.gitignore
+++ b/plugin/test/fixtures/custom-functions-directory/.gitignore
@@ -3,8 +3,7 @@ node_modules/
 public
 
 # Local Netlify folder
-.netlify/cache
-.netlify/functions
+.netlify
 
 deployment.json
 

--- a/plugin/test/fixtures/custom-functions-directory/.netlify/state.json
+++ b/plugin/test/fixtures/custom-functions-directory/.netlify/state.json
@@ -1,3 +1,0 @@
-{
-	"siteId": "3e2bfaf8-ea4e-4fef-8660-0267289dbc77"
-}

--- a/plugin/test/fixtures/custom-functions-directory/package.json
+++ b/plugin/test/fixtures/custom-functions-directory/package.json
@@ -13,7 +13,7 @@
     "build": "gatsby build",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
-    "build:netlify": "NETLIFY_AUTH_TOKEN=fake netlify build",
+    "build:netlify": "netlify build --offline",
     "preview": "netlify dev --offline",
     "test": "run-s build:netlify test:e2e",
     "test:e2e": "start-server-and-test preview 8888 test:jest",

--- a/plugin/test/fixtures/functions-without-gatsby-plugin/.gitignore
+++ b/plugin/test/fixtures/functions-without-gatsby-plugin/.gitignore
@@ -3,9 +3,7 @@ node_modules/
 public
 
 # Local Netlify folder
-.netlify/cache
-.netlify/functions
-
+.netlify
 netlify/functions/gatsby/functions
 deployment.json
 

--- a/plugin/test/fixtures/functions-without-gatsby-plugin/.netlify/state.json
+++ b/plugin/test/fixtures/functions-without-gatsby-plugin/.netlify/state.json
@@ -1,3 +1,0 @@
-{
-	"siteId": "3e2bfaf8-ea4e-4fef-8660-0267289dbc77"
-}

--- a/plugin/test/fixtures/functions-without-gatsby-plugin/package.json
+++ b/plugin/test/fixtures/functions-without-gatsby-plugin/package.json
@@ -13,7 +13,7 @@
     "build": "gatsby build",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
-    "build:netlify": "NETLIFY_AUTH_TOKEN=fake netlify build",
+    "build:netlify": "netlify build --offline",
     "preview": "netlify dev --offline",
     "test": "run-s build:netlify test:e2e",
     "test:e2e": "start-server-and-test preview 8888 test:jest",

--- a/plugin/test/fixtures/no-functions/.netlify/state.json
+++ b/plugin/test/fixtures/no-functions/.netlify/state.json
@@ -1,3 +1,0 @@
-{
-	"siteId": "3e2bfaf8-ea4e-4fef-8660-0267289dbc77"
-}

--- a/plugin/test/fixtures/with-no-gatsby-config/.netlify/state.json
+++ b/plugin/test/fixtures/with-no-gatsby-config/.netlify/state.json
@@ -1,3 +1,0 @@
-{
-	"siteId": "3e2bfaf8-ea4e-4fef-8660-0267289dbc77"
-}

--- a/plugin/test/fixtures/with-no-plugins/.gitignore
+++ b/plugin/test/fixtures/with-no-plugins/.gitignore
@@ -1,6 +1,5 @@
 node_modules/
 .cache/
 public
-.netlify/cache
-.netlify/functions
+.netlify
 package-lock.json

--- a/plugin/test/fixtures/with-no-plugins/.netlify/state.json
+++ b/plugin/test/fixtures/with-no-plugins/.netlify/state.json
@@ -1,3 +1,0 @@
-{
-	"siteId": "3e2bfaf8-ea4e-4fef-8660-0267289dbc77"
-}

--- a/plugin/test/fixtures/with-old-gatsby-plugin/.gitignore
+++ b/plugin/test/fixtures/with-old-gatsby-plugin/.gitignore
@@ -1,6 +1,5 @@
 node_modules/
 .cache/
 public
-.netlify/cache
-.netlify/functions
+.netlify
 package-lock.json

--- a/plugin/test/fixtures/with-old-gatsby-plugin/.netlify/state.json
+++ b/plugin/test/fixtures/with-old-gatsby-plugin/.netlify/state.json
@@ -1,3 +1,0 @@
-{
-	"siteId": "3e2bfaf8-ea4e-4fef-8660-0267289dbc77"
-}

--- a/plugin/test/fixtures/with-old-netlify-plugin/.gitignore
+++ b/plugin/test/fixtures/with-old-netlify-plugin/.gitignore
@@ -1,6 +1,5 @@
 node_modules/
 .cache/
 public
-.netlify/cache
-.netlify/functions
+.netlify
 package-lock.json

--- a/plugin/test/fixtures/with-old-netlify-plugin/.netlify/state.json
+++ b/plugin/test/fixtures/with-old-netlify-plugin/.netlify/state.json
@@ -1,3 +1,0 @@
-{
-	"siteId": "3e2bfaf8-ea4e-4fef-8660-0267289dbc77"
-}


### PR DESCRIPTION
Use the new `--offline` flag for builds rather than passing a fake token, which seems to be breaking tests