### PR TITLE
fix: conditionally proxy dev functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ node_modules
 /yarn.lock
 .cache
 public
+.DS_Store

--- a/demo/.env.development
+++ b/demo/.env.development
@@ -1,1 +1,4 @@
 pickle=word
+# @netlify/plugin-gatsby start
+GATSBY_PRECOMPILE_DEVELOP_FUNCTIONS=true
+# @netlify/plugin-gatsby end

--- a/demo/package.json
+++ b/demo/package.json
@@ -20,7 +20,7 @@
     "test:jest": "jest"
   },
   "dependencies": {
-    "gatsby": "^3.6.2",
+    "gatsby": "^3.12.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   },
@@ -29,15 +29,15 @@
     "co-body": "^6.1.0",
     "cookie": "^0.4.1",
     "download": "^8.0.0",
-    "fs-extra": "^10.0.0",
-    "multer": "^1.4.2",
-    "path-to-regexp": "^6.0.0",
-    "tempy": "^1.0.0",
     "form-data": "^4.0.0",
+    "fs-extra": "^10.0.0",
     "jest": "^27.0.0",
+    "multer": "^1.4.2",
     "node-fetch": "^2.6.1",
     "npm-run-all": "^4.1.5",
-    "start-server-and-test": "^1.12.2"
+    "path-to-regexp": "^6.0.0",
+    "start-server-and-test": "^1.12.2",
+    "tempy": "^1.0.0"
   },
   "license": "MIT",
   "engines": {

--- a/plugin/src/index.js
+++ b/plugin/src/index.js
@@ -146,6 +146,12 @@ The plugin no longer uses this and it should be deleted to avoid conflicts.\n`)
         fileName: gitignorePath,
       })
     }
+    await spliceConfig({
+      startMarker: '# @netlify/plugin-gatsby start',
+      endMarker: '# @netlify/plugin-gatsby end',
+      contents: `GATSBY_PRECOMPILE_DEVELOP_FUNCTIONS=true`,
+      fileName: path.resolve(path.join(PUBLISH_DIR, '..', '.env.development')),
+    })
   },
 
   async onPostBuild({ constants: { PUBLISH_DIR }, utils }) {

--- a/plugin/src/index.js
+++ b/plugin/src/index.js
@@ -122,15 +122,8 @@ Detected the function "${path.join(
 The plugin no longer uses this and it should be deleted to avoid conflicts.\n`)
     }
 
-    // copying Gatsby functions to functions directory
-
-    await fs.copy(
-      compiledFunctions,
-      path.join(functionsSrcDir, '__gatsby-functions', 'functions'),
-    )
-
     netlifyConfig.functions['__gatsby-functions'] = {
-      included_files: [`${functionsSrcDir}/__gatsby-functions/functions/**`],
+      included_files: [path.join(compiledFunctions, '**')],
     }
 
     const redirectsPath = path.resolve(`${PUBLISH_DIR}/_redirects`)

--- a/plugin/src/templates/__gatsby-functions.ts
+++ b/plugin/src/templates/__gatsby-functions.ts
@@ -1,30 +1,14 @@
 import createRequestObject from './createRequestObject'
 import createResponseObject from './createResponseObject'
 import gatsbyFunction from './gatsbyFunction'
-import { proxyRequest } from './functions'
 
 export async function handler(event, context) {
-  if (process.env.NETLIFY_DEV) {
-    return proxyRequest(event)
-  }
-
   const req = createRequestObject({ event, context })
-  let functions
-  try {
-    // This is generated in the user's site
-    // eslint-disable-next-line node/no-missing-require, node/no-unpublished-require
-    functions = require('./functions/manifest.json')
-  } catch (e) {
-    return {
-      statusCode: 404,
-      body: 'Could not load function manifest',
-    }
-  }
 
   return new Promise((onResEnd) => {
     const res = createResponseObject({ onResEnd })
     try {
-      gatsbyFunction(req, res, functions)
+      gatsbyFunction(req, res, event)
     } catch (e) {
       console.error(`Error executing ${event.path}`, e)
       onResEnd({ statusCode: 500 })

--- a/plugin/src/templates/createResponseObject.js
+++ b/plugin/src/templates/createResponseObject.js
@@ -20,7 +20,7 @@ const createResponseObject = ({ onResEnd }) => {
       response.statusCode = statusCode
     },
   })
-  res.headers = {}
+  res.headers = { 'content-type': 'text/plain; charset=utf-8' }
 
   res.writeHead = (status, headers) => {
     response.statusCode = status

--- a/plugin/test/fixtures/custom-functions-directory/e2e-tests/__snapshots__/functions.test.js.snap
+++ b/plugin/test/fixtures/custom-functions-directory/e2e-tests/__snapshots__/functions.test.js.snap
@@ -24,66 +24,6 @@ Object {
 }
 `;
 
-exports[`Local functions can parse different ways of sending data form data 1`] = `
-Object {
-  "a": "form-data",
-}
-`;
-
-exports[`Local functions can parse different ways of sending data form parameters 1`] = `
-Object {
-  "a": "form parameters",
-}
-`;
-
-exports[`Local functions can parse different ways of sending data json body 1`] = `
-Object {
-  "a": "json",
-}
-`;
-
-exports[`Local functions can parse different ways of sending data query string 1`] = `
-Object {
-  "amIReal": "true",
-}
-`;
-
-exports[`Local functions get parsed cookies cookie 1`] = `
-Object {
-  "foo": "blue",
-}
-`;
-
-exports[`Local response formats returns json correctly: headers 1`] = `
-Object {
-  "access-control-allow-origin": "*",
-  "connection": "close",
-  "content-length": "16",
-  "content-type": "application/json; charset=utf-8",
-  "vary": "Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Local response formats returns json correctly: result 1`] = `
-Object {
-  "amIJSON": true,
-}
-`;
-
-exports[`Local response formats returns text correctly: headers 1`] = `
-Object {
-  "access-control-allow-origin": "*",
-  "connection": "close",
-  "content-length": "15",
-  "content-type": "text/html; charset=utf-8",
-  "vary": "Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Local response formats returns text correctly: result 1`] = `"I am typescript"`;
-
 exports[`Local routing dynamic routes 1`] = `
 Object {
   "super": "additional",
@@ -106,13 +46,3 @@ exports[`Local routing routes with special characters 3`] = `"with-äöü-umlaut
 exports[`Local routing routes with special characters 4`] = `"some-àè-french.js"`;
 
 exports[`Local routing routes with special characters 5`] = `"some-אודות.js"`;
-
-exports[`Local routing secondary-level API 1`] = `"I am at a secondary-level"`;
-
-exports[`Local routing secondary-level API 2`] = `"I am another sub-directory function"`;
-
-exports[`Local routing secondary-level API with index.js 1`] = `"I am an index.js in a sub-directory!"`;
-
-exports[`Local routing top-level API 1`] = `"I am at the top-level"`;
-
-exports[`Local typescript typescript functions work 1`] = `"I am typescript"`;

--- a/plugin/test/fixtures/custom-functions-directory/e2e-tests/test-helpers.js
+++ b/plugin/test/fixtures/custom-functions-directory/e2e-tests/test-helpers.js
@@ -7,35 +7,43 @@ const { readFileSync } = require('fs')
 // Source: https://github.com/gatsbyjs/gatsby/blob/master/integration-tests/functions/test-helpers.js
 
 exports.runTests = function runTests(env, host) {
+  async function fetchTwice(url, options) {
+    const result = await fetch(url, options)
+    if (!result.headers.has('x-forwarded-host')) {
+      return result
+    }
+    return fetch(url, options)
+  }
+
   describe(env, () => {
     describe(`routing`, () => {
       test(`top-level API`, async () => {
-        const result = await fetch(`${host}/api/top-level`).then((res) =>
+        const result = await fetchTwice(`${host}/api/top-level`).then((res) =>
           res.text(),
         )
 
-        expect(result).toMatchSnapshot()
+        expect(result).toEqual('I am at the top-level')
       })
       test(`secondary-level API`, async () => {
-        const result = await fetch(`${host}/api/a-directory/function`).then(
+        const result = await fetchTwice(
+          `${host}/api/a-directory/function`,
+        ).then((res) => res.text())
+
+        expect(result).toEqual('I am at a secondary-level')
+      })
+      test(`secondary-level API with index.js`, async () => {
+        const result = await fetchTwice(`${host}/api/a-directory`).then((res) =>
+          res.text(),
+        )
+
+        expect(result).toEqual('I am an index.js in a sub-directory!')
+      })
+      test(`secondary-level API`, async () => {
+        const result = await fetchTwice(`${host}/api/dir/function`).then(
           (res) => res.text(),
         )
 
-        expect(result).toMatchSnapshot()
-      })
-      test(`secondary-level API with index.js`, async () => {
-        const result = await fetch(`${host}/api/a-directory`).then((res) =>
-          res.text(),
-        )
-
-        expect(result).toMatchSnapshot()
-      })
-      test(`secondary-level API`, async () => {
-        const result = await fetch(`${host}/api/dir/function`).then((res) =>
-          res.text(),
-        )
-
-        expect(result).toMatchSnapshot()
+        expect(result).toEqual('I am another sub-directory function')
       })
       test(`routes with special characters`, async () => {
         const routes = [
@@ -47,7 +55,7 @@ exports.runTests = function runTests(env, host) {
         ]
 
         for (const route of routes) {
-          const result = await fetch(route).then((res) => res.text())
+          const result = await fetchTwice(route).then((res) => res.text())
 
           expect(result).toMatchSnapshot()
         }
@@ -60,7 +68,7 @@ exports.runTests = function runTests(env, host) {
         ]
 
         for (const route of routes) {
-          const result = await fetch(route).then((res) => res.json())
+          const result = await fetchTwice(route).then((res) => res.json())
 
           expect(result).toMatchSnapshot()
         }
@@ -69,8 +77,8 @@ exports.runTests = function runTests(env, host) {
 
     describe(`environment variables`, () => {
       test(`can use inside functions`, async () => {
-        const result = await fetch(`${host}/api/env-variables`).then((res) =>
-          res.text(),
+        const result = await fetchTwice(`${host}/api/env-variables`).then(
+          (res) => res.text(),
         )
 
         expect(result).toEqual(`word`)
@@ -79,18 +87,18 @@ exports.runTests = function runTests(env, host) {
 
     describe(`typescript`, () => {
       test(`typescript functions work`, async () => {
-        const result = await fetch(`${host}/api/i-am-typescript`).then((res) =>
-          res.text(),
+        const result = await fetchTwice(`${host}/api/i-am-typescript`).then(
+          (res) => res.text(),
         )
 
-        expect(result).toMatchSnapshot()
+        expect(result).toEqual('I am typescript')
       })
     })
 
     describe(`function errors don't crash the server`, () => {
       // This test mainly just shows that the server doesn't crash.
       test(`normal`, async () => {
-        const result = await fetch(`${host}/api/error-send-function-twice`)
+        const result = await fetchTwice(`${host}/api/error-send-function-twice`)
 
         expect(result.status).toEqual(200)
       })
@@ -98,38 +106,40 @@ exports.runTests = function runTests(env, host) {
 
     describe(`response formats`, () => {
       test(`returns json correctly`, async () => {
-        const res = await fetch(`${host}/api/i-am-json`)
+        const res = await fetchTwice(`${host}/api/i-am-json`)
         const result = await res.json()
 
-        const { date, etag, ...headers } = Object.fromEntries(res.headers)
-        expect(result).toMatchSnapshot('result')
-        expect(headers).toMatchSnapshot('headers')
+        expect(result).toEqual({
+          amIJSON: true,
+        })
+        expect(res.headers.get('content-type')).toEqual('application/json')
       })
       test(`returns text correctly`, async () => {
-        const res = await fetch(`${host}/api/i-am-typescript`)
+        const res = await fetchTwice(`${host}/api/i-am-text`)
         const result = await res.text()
 
-        const { date, etag, ...headers } = Object.fromEntries(res.headers)
-        expect(result).toMatchSnapshot('result')
-        expect(headers).toMatchSnapshot('headers')
+        expect(result).toEqual('I am text')
+        expect(res.headers.get('content-type')).toEqual(
+          'text/plain; charset=utf-8',
+        )
       })
     })
 
     describe(`functions can send custom statuses`, () => {
       test(`can return 200 status`, async () => {
-        const res = await fetch(`${host}/api/status`)
+        const res = await fetchTwice(`${host}/api/status`)
 
         expect(res.status).toEqual(200)
       })
 
       test(`can return 404 status`, async () => {
-        const res = await fetch(`${host}/api/status?code=404`)
+        const res = await fetchTwice(`${host}/api/status?code=404`)
 
         expect(res.status).toEqual(404)
       })
 
       test(`can return 500 status`, async () => {
-        const res = await fetch(`${host}/api/status?code=500`)
+        const res = await fetchTwice(`${host}/api/status?code=500`)
 
         expect(res.status).toEqual(500)
       })
@@ -137,45 +147,53 @@ exports.runTests = function runTests(env, host) {
 
     describe(`functions can parse different ways of sending data`, () => {
       test(`query string`, async () => {
-        const result = await fetch(`${host}/api/parser?amIReal=true`).then(
+        const result = await fetchTwice(`${host}/api/parser?amIReal=true`).then(
           (res) => res.json(),
         )
 
-        expect(result).toMatchSnapshot()
+        expect(result).toEqual({
+          amIReal: 'true',
+        })
       })
 
       test(`form parameters`, async () => {
         const { URLSearchParams } = require('url')
         const params = new URLSearchParams()
         params.append('a', `form parameters`)
-        const result = await fetch(`${host}/api/parser`, {
+        const result = await fetchTwice(`${host}/api/parser`, {
           method: `POST`,
           body: params,
         }).then((res) => res.json())
 
-        expect(result).toMatchSnapshot()
+        expect(result).toEqual({
+          a: 'form parameters',
+        })
       })
 
       test(`form data`, async () => {
         const form = new FormData()
         form.append('a', `form-data`)
-        const result = await fetch(`${host}/api/parser`, {
+        const result = await fetchTwice(`${host}/api/parser`, {
           method: `POST`,
           body: form,
         }).then((res) => res.json())
 
-        expect(result).toMatchSnapshot()
+        expect(result).toEqual({
+          a: 'form-data',
+        })
       })
 
       test(`json body`, async () => {
         const body = { a: `json` }
-        const result = await fetch(`${host}/api/parser`, {
+        const result = await fetchTwice(`${host}/api/parser`, {
           method: `POST`,
           body: JSON.stringify(body),
           headers: { 'Content-Type': 'application/json' },
         }).then((res) => res.json())
 
-        expect(result).toMatchSnapshot()
+        expect(result).toEqual({
+          a: 'json',
+        })
       })
 
       it(`file in multipart/form`, async () => {
@@ -187,7 +205,7 @@ exports.runTests = function runTests(env, host) {
           contentType: 'text/plain',
         })
         form.append('something', 'here')
-        const result = await fetch(`${host}/api/parser`, {
+        const result = await fetchTwice(`${host}/api/parser`, {
           method: `POST`,
           body: form,
           headers: form.getHeaders(),
@@ -199,17 +217,19 @@ exports.runTests = function runTests(env, host) {
 
     describe(`functions get parsed cookies`, () => {
       test(`cookie`, async () => {
-        const result = await fetch(`${host}/api/cookie-me`, {
+        const result = await fetchTwice(`${host}/api/cookie-me`, {
           headers: { cookie: `foo=blue;` },
         }).then((res) => res.json())
 
-        expect(result).toMatchSnapshot()
+        expect(result).toEqual({
+          foo: 'blue',
+        })
       })
     })
 
     describe(`functions can redirect`, () => {
       test(`normal`, async () => {
-        const result = await fetch(`${host}/api/redirect-me`)
+        const result = await fetchTwice(`${host}/api/redirect-me`)
 
         expect(result.url).toEqual(host + `/`)
       })
@@ -217,7 +237,7 @@ exports.runTests = function runTests(env, host) {
 
     describe(`functions can have custom middleware`, () => {
       test(`normal`, async () => {
-        const result = await fetch(`${host}/api/cors`)
+        const result = await fetchTwice(`${host}/api/cors`)
 
         const headers = Object.fromEntries(result.headers)
         expect(headers[`access-control-allow-origin`]).toEqual(`*`)

--- a/plugin/test/fixtures/custom-functions-directory/src/api/i-am-text.js
+++ b/plugin/test/fixtures/custom-functions-directory/src/api/i-am-text.js
@@ -1,0 +1,3 @@
+export default function topLevel(req, res) {
+  res.send('I am text')
+}

--- a/plugin/test/fixtures/functions-without-gatsby-plugin/e2e-tests/__snapshots__/functions.test.js.snap
+++ b/plugin/test/fixtures/functions-without-gatsby-plugin/e2e-tests/__snapshots__/functions.test.js.snap
@@ -24,62 +24,6 @@ Object {
 }
 `;
 
-exports[`Local functions can parse different ways of sending data form data 1`] = `
-Object {
-  "a": "form-data",
-}
-`;
-
-exports[`Local functions can parse different ways of sending data form parameters 1`] = `
-Object {
-  "a": "form parameters",
-}
-`;
-
-exports[`Local functions can parse different ways of sending data json body 1`] = `
-Object {
-  "a": "json",
-}
-`;
-
-exports[`Local functions can parse different ways of sending data query string 1`] = `
-Object {
-  "amIReal": "true",
-}
-`;
-
-exports[`Local functions get parsed cookies cookie 1`] = `
-Object {
-  "foo": "blue",
-}
-`;
-
-exports[`Local response formats returns json correctly: headers 1`] = `
-Object {
-  "connection": "close",
-  "content-type": "application/json",
-  "transfer-encoding": "chunked",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Local response formats returns json correctly: result 1`] = `
-Object {
-  "amIJSON": true,
-}
-`;
-
-exports[`Local response formats returns text correctly: headers 1`] = `
-Object {
-  "connection": "close",
-  "content-type": "text/plain; charset=utf-8",
-  "transfer-encoding": "chunked",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Local response formats returns text correctly: result 1`] = `"I am typescript"`;
-
 exports[`Local routing dynamic routes 1`] = `
 Object {
   "super": "additional",
@@ -102,13 +46,3 @@ exports[`Local routing routes with special characters 3`] = `"with-äöü-umlaut
 exports[`Local routing routes with special characters 4`] = `"some-àè-french.js"`;
 
 exports[`Local routing routes with special characters 5`] = `"some-אודות.js"`;
-
-exports[`Local routing secondary-level API 1`] = `"I am at a secondary-level"`;
-
-exports[`Local routing secondary-level API 2`] = `"I am another sub-directory function"`;
-
-exports[`Local routing secondary-level API with index.js 1`] = `"I am an index.js in a sub-directory!"`;
-
-exports[`Local routing top-level API 1`] = `"I am at the top-level"`;
-
-exports[`Local typescript typescript functions work 1`] = `"I am typescript"`;

--- a/plugin/test/fixtures/functions-without-gatsby-plugin/e2e-tests/__snapshots__/functions.test.js.snap
+++ b/plugin/test/fixtures/functions-without-gatsby-plugin/e2e-tests/__snapshots__/functions.test.js.snap
@@ -56,11 +56,9 @@ Object {
 
 exports[`Local response formats returns json correctly: headers 1`] = `
 Object {
-  "access-control-allow-origin": "*",
   "connection": "close",
-  "content-length": "16",
-  "content-type": "application/json; charset=utf-8",
-  "vary": "Accept-Encoding",
+  "content-type": "application/json",
+  "transfer-encoding": "chunked",
   "x-powered-by": "Express",
 }
 `;
@@ -73,11 +71,9 @@ Object {
 
 exports[`Local response formats returns text correctly: headers 1`] = `
 Object {
-  "access-control-allow-origin": "*",
   "connection": "close",
-  "content-length": "15",
-  "content-type": "text/html; charset=utf-8",
-  "vary": "Accept-Encoding",
+  "content-type": "text/plain; charset=utf-8",
+  "transfer-encoding": "chunked",
   "x-powered-by": "Express",
 }
 `;

--- a/plugin/test/fixtures/functions-without-gatsby-plugin/e2e-tests/functions.test.js
+++ b/plugin/test/fixtures/functions-without-gatsby-plugin/e2e-tests/functions.test.js
@@ -1,8 +1,8 @@
-const { runTests } = require("./test-helpers");
+const { runTests } = require('./test-helpers')
 
-if (process.env.TEST_ENV === "netlify") {
-  const { deploy_url } = require("../deployment.json");
-  runTests("Netlify", deploy_url);
+if (process.env.TEST_ENV === 'netlify') {
+  const { deploy_url } = require('../deployment.json')
+  runTests('Netlify', deploy_url)
 } else {
-  runTests("Local", "http://localhost:8888");
+  runTests('Local', 'http://localhost:8888')
 }

--- a/plugin/test/fixtures/functions-without-gatsby-plugin/e2e-tests/test-helpers.js
+++ b/plugin/test/fixtures/functions-without-gatsby-plugin/e2e-tests/test-helpers.js
@@ -7,32 +7,40 @@ const { readFileSync } = require('fs')
 // Source: https://github.com/gatsbyjs/gatsby/blob/master/integration-tests/functions/test-helpers.js
 
 exports.runTests = function runTests(env, host) {
+  async function fetchTwice(url, options) {
+    const result = await fetch(url, options)
+    if (!result.headers.has('x-forwarded-host')) {
+      return result
+    }
+    return fetch(url, options)
+  }
+
   describe(env, () => {
     describe(`routing`, () => {
       test(`top-level API`, async () => {
-        const result = await fetch(`${host}/api/top-level`).then((res) =>
+        const result = await fetchTwice(`${host}/api/top-level`).then((res) =>
           res.text(),
         )
 
         expect(result).toMatchSnapshot()
       })
       test(`secondary-level API`, async () => {
-        const result = await fetch(`${host}/api/a-directory/function`).then(
-          (res) => res.text(),
-        )
+        const result = await fetchTwice(
+          `${host}/api/a-directory/function`,
+        ).then((res) => res.text())
 
         expect(result).toMatchSnapshot()
       })
       test(`secondary-level API with index.js`, async () => {
-        const result = await fetch(`${host}/api/a-directory`).then((res) =>
+        const result = await fetchTwice(`${host}/api/a-directory`).then((res) =>
           res.text(),
         )
 
         expect(result).toMatchSnapshot()
       })
       test(`secondary-level API`, async () => {
-        const result = await fetch(`${host}/api/dir/function`).then((res) =>
-          res.text(),
+        const result = await fetchTwice(`${host}/api/dir/function`).then(
+          (res) => res.text(),
         )
 
         expect(result).toMatchSnapshot()
@@ -47,7 +55,7 @@ exports.runTests = function runTests(env, host) {
         ]
 
         for (const route of routes) {
-          const result = await fetch(route).then((res) => res.text())
+          const result = await fetchTwice(route).then((res) => res.text())
 
           expect(result).toMatchSnapshot()
         }
@@ -60,7 +68,7 @@ exports.runTests = function runTests(env, host) {
         ]
 
         for (const route of routes) {
-          const result = await fetch(route).then((res) => res.json())
+          const result = await fetchTwice(route).then((res) => res.json())
 
           expect(result).toMatchSnapshot()
         }
@@ -69,8 +77,8 @@ exports.runTests = function runTests(env, host) {
 
     describe(`environment variables`, () => {
       test(`can use inside functions`, async () => {
-        const result = await fetch(`${host}/api/env-variables`).then((res) =>
-          res.text(),
+        const result = await fetchTwice(`${host}/api/env-variables`).then(
+          (res) => res.text(),
         )
 
         expect(result).toEqual(`word`)
@@ -79,8 +87,8 @@ exports.runTests = function runTests(env, host) {
 
     describe(`typescript`, () => {
       test(`typescript functions work`, async () => {
-        const result = await fetch(`${host}/api/i-am-typescript`).then((res) =>
-          res.text(),
+        const result = await fetchTwice(`${host}/api/i-am-typescript`).then(
+          (res) => res.text(),
         )
 
         expect(result).toMatchSnapshot()
@@ -90,7 +98,7 @@ exports.runTests = function runTests(env, host) {
     describe(`function errors don't crash the server`, () => {
       // This test mainly just shows that the server doesn't crash.
       test(`normal`, async () => {
-        const result = await fetch(`${host}/api/error-send-function-twice`)
+        const result = await fetchTwice(`${host}/api/error-send-function-twice`)
 
         expect(result.status).toEqual(200)
       })
@@ -98,7 +106,7 @@ exports.runTests = function runTests(env, host) {
 
     describe(`response formats`, () => {
       test(`returns json correctly`, async () => {
-        const res = await fetch(`${host}/api/i-am-json`)
+        const res = await fetchTwice(`${host}/api/i-am-json`)
         const result = await res.json()
 
         const { date, etag, ...headers } = Object.fromEntries(res.headers)
@@ -106,7 +114,7 @@ exports.runTests = function runTests(env, host) {
         expect(headers).toMatchSnapshot('headers')
       })
       test(`returns text correctly`, async () => {
-        const res = await fetch(`${host}/api/i-am-typescript`)
+        const res = await fetchTwice(`${host}/api/i-am-typescript`)
         const result = await res.text()
 
         const { date, etag, ...headers } = Object.fromEntries(res.headers)
@@ -117,19 +125,19 @@ exports.runTests = function runTests(env, host) {
 
     describe(`functions can send custom statuses`, () => {
       test(`can return 200 status`, async () => {
-        const res = await fetch(`${host}/api/status`)
+        const res = await fetchTwice(`${host}/api/status`)
 
         expect(res.status).toEqual(200)
       })
 
       test(`can return 404 status`, async () => {
-        const res = await fetch(`${host}/api/status?code=404`)
+        const res = await fetchTwice(`${host}/api/status?code=404`)
 
         expect(res.status).toEqual(404)
       })
 
       test(`can return 500 status`, async () => {
-        const res = await fetch(`${host}/api/status?code=500`)
+        const res = await fetchTwice(`${host}/api/status?code=500`)
 
         expect(res.status).toEqual(500)
       })
@@ -137,7 +145,7 @@ exports.runTests = function runTests(env, host) {
 
     describe(`functions can parse different ways of sending data`, () => {
       test(`query string`, async () => {
-        const result = await fetch(`${host}/api/parser?amIReal=true`).then(
+        const result = await fetchTwice(`${host}/api/parser?amIReal=true`).then(
           (res) => res.json(),
         )
 
@@ -148,7 +156,7 @@ exports.runTests = function runTests(env, host) {
         const { URLSearchParams } = require('url')
         const params = new URLSearchParams()
         params.append('a', `form parameters`)
-        const result = await fetch(`${host}/api/parser`, {
+        const result = await fetchTwice(`${host}/api/parser`, {
           method: `POST`,
           body: params,
         }).then((res) => res.json())
@@ -159,7 +167,7 @@ exports.runTests = function runTests(env, host) {
       test(`form data`, async () => {
         const form = new FormData()
         form.append('a', `form-data`)
-        const result = await fetch(`${host}/api/parser`, {
+        const result = await fetchTwice(`${host}/api/parser`, {
           method: `POST`,
           body: form,
         }).then((res) => res.json())
@@ -169,7 +177,7 @@ exports.runTests = function runTests(env, host) {
 
       test(`json body`, async () => {
         const body = { a: `json` }
-        const result = await fetch(`${host}/api/parser`, {
+        const result = await fetchTwice(`${host}/api/parser`, {
           method: `POST`,
           body: JSON.stringify(body),
           headers: { 'Content-Type': 'application/json' },
@@ -187,7 +195,7 @@ exports.runTests = function runTests(env, host) {
           contentType: 'text/plain',
         })
         form.append('something', 'here')
-        const result = await fetch(`${host}/api/parser`, {
+        const result = await fetchTwice(`${host}/api/parser`, {
           method: `POST`,
           body: form,
           headers: form.getHeaders(),
@@ -199,7 +207,7 @@ exports.runTests = function runTests(env, host) {
 
     describe(`functions get parsed cookies`, () => {
       test(`cookie`, async () => {
-        const result = await fetch(`${host}/api/cookie-me`, {
+        const result = await fetchTwice(`${host}/api/cookie-me`, {
           headers: { cookie: `foo=blue;` },
         }).then((res) => res.json())
 
@@ -209,7 +217,7 @@ exports.runTests = function runTests(env, host) {
 
     describe(`functions can redirect`, () => {
       test(`normal`, async () => {
-        const result = await fetch(`${host}/api/redirect-me`)
+        const result = await fetchTwice(`${host}/api/redirect-me`)
 
         expect(result.url).toEqual(host + `/`)
       })
@@ -217,7 +225,7 @@ exports.runTests = function runTests(env, host) {
 
     describe(`functions can have custom middleware`, () => {
       test(`normal`, async () => {
-        const result = await fetch(`${host}/api/cors`)
+        const result = await fetchTwice(`${host}/api/cors`)
 
         const headers = Object.fromEntries(result.headers)
         expect(headers[`access-control-allow-origin`]).toEqual(`*`)

--- a/plugin/test/fixtures/functions-without-gatsby-plugin/e2e-tests/test-helpers.js
+++ b/plugin/test/fixtures/functions-without-gatsby-plugin/e2e-tests/test-helpers.js
@@ -22,28 +22,28 @@ exports.runTests = function runTests(env, host) {
           res.text(),
         )
 
-        expect(result).toMatchSnapshot()
+        expect(result).toEqual('I am at the top-level')
       })
       test(`secondary-level API`, async () => {
         const result = await fetchTwice(
           `${host}/api/a-directory/function`,
         ).then((res) => res.text())
 
-        expect(result).toMatchSnapshot()
+        expect(result).toEqual('I am at a secondary-level')
       })
       test(`secondary-level API with index.js`, async () => {
         const result = await fetchTwice(`${host}/api/a-directory`).then((res) =>
           res.text(),
         )
 
-        expect(result).toMatchSnapshot()
+        expect(result).toEqual('I am an index.js in a sub-directory!')
       })
       test(`secondary-level API`, async () => {
         const result = await fetchTwice(`${host}/api/dir/function`).then(
           (res) => res.text(),
         )
 
-        expect(result).toMatchSnapshot()
+        expect(result).toEqual('I am another sub-directory function')
       })
       test(`routes with special characters`, async () => {
         const routes = [
@@ -91,7 +91,7 @@ exports.runTests = function runTests(env, host) {
           (res) => res.text(),
         )
 
-        expect(result).toMatchSnapshot()
+        expect(result).toEqual('I am typescript')
       })
     })
 
@@ -109,17 +109,19 @@ exports.runTests = function runTests(env, host) {
         const res = await fetchTwice(`${host}/api/i-am-json`)
         const result = await res.json()
 
-        const { date, etag, ...headers } = Object.fromEntries(res.headers)
-        expect(result).toMatchSnapshot('result')
-        expect(headers).toMatchSnapshot('headers')
+        expect(result).toEqual({
+          amIJSON: true,
+        })
+        expect(res.headers.get('content-type')).toEqual('application/json')
       })
       test(`returns text correctly`, async () => {
-        const res = await fetchTwice(`${host}/api/i-am-typescript`)
+        const res = await fetchTwice(`${host}/api/i-am-text`)
         const result = await res.text()
 
-        const { date, etag, ...headers } = Object.fromEntries(res.headers)
-        expect(result).toMatchSnapshot('result')
-        expect(headers).toMatchSnapshot('headers')
+        expect(result).toEqual('I am text')
+        expect(res.headers.get('content-type')).toEqual(
+          'text/plain; charset=utf-8',
+        )
       })
     })
 
@@ -149,7 +151,9 @@ exports.runTests = function runTests(env, host) {
           (res) => res.json(),
         )
 
-        expect(result).toMatchSnapshot()
+        expect(result).toEqual({
+          amIReal: 'true',
+        })
       })
 
       test(`form parameters`, async () => {
@@ -161,7 +165,9 @@ exports.runTests = function runTests(env, host) {
           body: params,
         }).then((res) => res.json())
 
-        expect(result).toMatchSnapshot()
+        expect(result).toEqual({
+          a: 'form parameters',
+        })
       })
 
       test(`form data`, async () => {
@@ -172,7 +178,9 @@ exports.runTests = function runTests(env, host) {
           body: form,
         }).then((res) => res.json())
 
-        expect(result).toMatchSnapshot()
+        expect(result).toEqual({
+          a: 'form-data',
+        })
       })
 
       test(`json body`, async () => {
@@ -183,7 +191,9 @@ exports.runTests = function runTests(env, host) {
           headers: { 'Content-Type': 'application/json' },
         }).then((res) => res.json())
 
-        expect(result).toMatchSnapshot()
+        expect(result).toEqual({
+          a: 'json',
+        })
       })
 
       it(`file in multipart/form`, async () => {
@@ -211,7 +221,9 @@ exports.runTests = function runTests(env, host) {
           headers: { cookie: `foo=blue;` },
         }).then((res) => res.json())
 
-        expect(result).toMatchSnapshot()
+        expect(result).toEqual({
+          foo: 'blue',
+        })
       })
     })
 

--- a/plugin/test/fixtures/functions-without-gatsby-plugin/src/api/i-am-text.js
+++ b/plugin/test/fixtures/functions-without-gatsby-plugin/src/api/i-am-text.js
@@ -1,0 +1,3 @@
+export default function topLevel(req, res) {
+  res.send('I am text')
+}


### PR DESCRIPTION
In `dev`, only proxy the fucntion to gatsby develop if the compiled file doesn't exist, otherwise serve it directly like in prod.