### PR TITLE
doc(README): fix the version that it's truly available to have the fix to support 12.x.x node versions in netlify

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ package = "@netlify/plugin-gatsby"
    `package.json`.
 
 ```shell
-npm install -D @netlify/plugin-gatsby@^2.0.0-beta
+npm install -D @netlify/plugin-gatsby@latest
 ```
 
 Read more about


### PR DESCRIPTION
The PR is solving the documentation instructions because when adding this package to the project at that version the build wouldn't work because it errored that the plugin needs a node version above 14.15.0 
```
The Node.js version is 12.22.7 but the plugin "@netlify/plugin-gatsby" requires >=14.15.0
```

But investigating I saw from this issue https://github.com/netlify/netlify-plugin-gatsby/issues/10 that the plugin did support now the Netlify's node version 12, included in this PR: https://github.com/netlify/netlify-plugin-gatsby/pull/12

So it took a long time of troubleshooting and trying things. Changing the install target in your README, solved the issue. 