### PR TITLE
Remove docs on setting AWS_LAMBDA_JS_RUNTIME

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,14 +84,6 @@ See
 [the gatsby-plugin-netlify docs](https://github.com/netlify/gatsby-plugin-netlify/)
 for more information, including optional plugin configuration.
 
-### Build configuration
-
-Gatsby now requires Node 14 for building and SSR/DSG. During the beta period you
-need to manually set the environment variable `AWS_LAMBDA_JS_RUNTIME` to
-`nodejs14.x` to ensure SSR and DSR use the correct version. This must be done in
-the Netlify UI, not in the `netlify.toml`. Read the docs on
-[choosing a functions runtime](https://docs.netlify.com/functions/build-with-javascript/#runtime-settings).
-
 ### Caveats
 
 Currently you cannot use `StaticImage` or `gatsby-transformer-sharp` in SSR or


### PR DESCRIPTION
AWS_LAMBDA_JS_RUNTIME defaults to 14 now so we can remove this note from the docs