### PR TITLE
feat: handle large zipfiles

### DIFF
--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@netlify/functions": "^0.11.0",
+        "chalk": "^4.1.2",
         "co-body": "^6.1.0",
         "cookie": "^0.4.1",
         "download": "^8.0.0",
@@ -18,7 +19,9 @@
         "linkfs": "^2.1.0",
         "multer": "^1.4.2",
         "node-fetch": "^2.6.1",
+        "node-stream-zip": "^1.15.0",
         "pathe": "^0.2.0",
+        "pretty-bytes": "^5.6.0",
         "tempy": "^1.0.0"
       },
       "devDependencies": {
@@ -26,7 +29,7 @@
         "@netlify/build": "^26.2.0",
         "@types/fs-extra": "^9.0.12",
         "@types/multer": "^1.4.7",
-        "gatsby": "^4.5.4",
+        "gatsby": "^4.3.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^3.0.2",
         "typescript": "^4.5.2"
@@ -5289,7 +5292,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -6483,7 +6485,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -6904,7 +6905,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -6915,8 +6915,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -12738,7 +12737,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -15635,6 +15633,18 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/node-stream-zip": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.15.0.tgz",
+      "integrity": "sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==",
+      "engines": {
+        "node": ">=0.12.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/antelle"
+      }
+    },
     "node_modules/nopt": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
@@ -17818,6 +17828,17 @@
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pretty-bytes": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pretty-error": {
@@ -20681,7 +20702,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -26798,7 +26818,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -27729,7 +27748,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -28061,7 +28079,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -28069,8 +28086,7 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "color-support": {
       "version": "1.1.3",
@@ -32582,8 +32598,7 @@
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "has-glob": {
       "version": "1.0.0",
@@ -34846,6 +34861,11 @@
         "@babel/parser": "^7.0.0"
       }
     },
+    "node-stream-zip": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.15.0.tgz",
+      "integrity": "sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw=="
+    },
     "nopt": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
@@ -36430,6 +36450,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+    },
+    "pretty-bytes": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg=="
     },
     "pretty-error": {
       "version": "2.1.2",
@@ -38690,7 +38715,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
       }

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@netlify/functions": "^0.11.0",
+    "chalk": "^4.1.2",
     "co-body": "^6.1.0",
     "cookie": "^0.4.1",
     "download": "^8.0.0",
@@ -50,7 +51,9 @@
     "linkfs": "^2.1.0",
     "multer": "^1.4.2",
     "node-fetch": "^2.6.1",
+    "node-stream-zip": "^1.15.0",
     "pathe": "^0.2.0",
+    "pretty-bytes": "^5.6.0",
     "tempy": "^1.0.0"
   },
   "devDependencies": {

--- a/plugin/src/helpers/config.ts
+++ b/plugin/src/helpers/config.ts
@@ -110,6 +110,7 @@ export function mutateConfig({
       path.posix.join(CACHE_DIR, 'data', '**'),
       path.posix.join(CACHE_DIR, 'query-engine', '**'),
       path.posix.join(CACHE_DIR, 'page-ssr', '**'),
+      '!**/*.js.map',
     ],
     external_node_modules: ['msgpackr-extract'],
     node_bundler: 'esbuild',

--- a/plugin/src/helpers/verification.ts
+++ b/plugin/src/helpers/verification.ts
@@ -11,6 +11,7 @@ import prettyBytes from 'pretty-bytes'
 // eslint-disable-next-line no-magic-numbers
 export const LAMBDA_MAX_SIZE = 1024 * 1024 * 50
 
+// eslint-disable-next-line max-statements
 export const checkZipSize = async (
   file: string,
   maxSize: number = LAMBDA_MAX_SIZE,
@@ -33,8 +34,7 @@ export const checkZipSize = async (
     )}, which is larger than the maximum supported size of ${prettyBytes(
       maxSize,
     )}.
-      There are a few reasons this could happen. You may have accidentally bundled a large dependency, or you might have a
-      large number of pre-rendered pages included.
+      There are a few reasons this could happen, such as accidentally bundling a large dependency or adding lots of files to "included_files".
     `),
   )
   const zip = new StreamZip({ file })
@@ -44,8 +44,8 @@ export const checkZipSize = async (
   )
 
   const largest = {}
-  // eslint-disable-next-line no-magic-numbers
-  for (let idx = 0; idx < 10 && idx < sortedFiles.length; idx++) {
+  const MAX_ROWS = 10
+  for (let idx = 0; idx < MAX_ROWS && idx < sortedFiles.length; idx++) {
     largest[`${idx + 1}`] = {
       File: sortedFiles[idx].name,
       'Compressed Size': prettyBytes(sortedFiles[idx].compressedSize),

--- a/plugin/src/helpers/verification.ts
+++ b/plugin/src/helpers/verification.ts
@@ -1,0 +1,57 @@
+import process from 'process'
+
+import { yellowBright, redBright } from 'chalk'
+import { stripIndent } from 'common-tags'
+import { existsSync, promises } from 'fs-extra'
+import { async as StreamZip } from 'node-stream-zip'
+import { relative } from 'pathe'
+import prettyBytes from 'pretty-bytes'
+
+// 50MB, which is the documented max, though the hard max seems to be higher
+// eslint-disable-next-line no-magic-numbers
+export const LAMBDA_MAX_SIZE = 1024 * 1024 * 50
+
+export const checkZipSize = async (
+  file: string,
+  maxSize: number = LAMBDA_MAX_SIZE,
+): Promise<void> => {
+  if (!existsSync(file)) {
+    console.warn(`Could not check zip size because ${file} does not exist`)
+    return
+  }
+  const fileSize = await promises.stat(file).then(({ size }) => size)
+  if (fileSize < maxSize) {
+    return
+  }
+  // We don't fail the build, because the actual hard max size is larger so it might still succeed
+  console.log(
+    redBright(stripIndent`
+      The function zip ${yellowBright(
+        relative(process.cwd(), file),
+      )} size is ${prettyBytes(
+      fileSize,
+    )}, which is larger than the maximum supported size of ${prettyBytes(
+      maxSize,
+    )}.
+      There are a few reasons this could happen. You may have accidentally bundled a large dependency, or you might have a
+      large number of pre-rendered pages included.
+    `),
+  )
+  const zip = new StreamZip({ file })
+  console.log(`Contains ${await zip.entriesCount} files`)
+  const sortedFiles = Object.values(await zip.entries()).sort(
+    (entryA, entryB) => entryB.size - entryA.size,
+  )
+
+  const largest = {}
+  // eslint-disable-next-line no-magic-numbers
+  for (let idx = 0; idx < 10 && idx < sortedFiles.length; idx++) {
+    largest[`${idx + 1}`] = {
+      File: sortedFiles[idx].name,
+      'Compressed Size': prettyBytes(sortedFiles[idx].compressedSize),
+      'Uncompressed Size': prettyBytes(sortedFiles[idx].size),
+    }
+  }
+  console.log(yellowBright`\n\nThese are the largest files in the zip:`)
+  console.table(largest)
+}

--- a/plugin/src/helpers/verification.ts
+++ b/plugin/src/helpers/verification.ts
@@ -52,6 +52,7 @@ export const checkZipSize = async (
       'Uncompressed Size': prettyBytes(sortedFiles[idx].size),
     }
   }
+  await zip.close()
   console.log(yellowBright`\n\nThese are the largest files in the zip:`)
   console.table(largest)
 }

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -6,6 +6,7 @@ import fs from 'fs-extra'
 import { normalizedCacheDir, restoreCache, saveCache } from './helpers/cache'
 import { checkGatsbyConfig, mutateConfig, spliceConfig } from './helpers/config'
 import { writeFunctions } from './helpers/functions'
+import { checkZipSize } from './helpers/verification'
 
 // eslint-disable-next-line no-template-curly-in-string
 const lmdbCacheString = 'process.cwd(), `.cache/${cacheDbFile}`'
@@ -104,8 +105,11 @@ The plugin no longer uses this and it should be deleted to avoid conflicts.\n`)
 }
 
 export async function onPostBuild({
-  constants: { PUBLISH_DIR },
+  constants: { PUBLISH_DIR, FUNCTIONS_DIST },
   utils,
 }): Promise<void> {
   await saveCache({ publish: PUBLISH_DIR, utils })
+  for (const func of ['api', 'dsg', 'ssr']) {
+    await checkZipSize(path.join(FUNCTIONS_DIST, `__${func}.zip`))
+  }
 }


### PR DESCRIPTION
Adds logging of largest files if the function zips are larger than 50MB. Also excludes all `*js.map` files by default.

Fixes #167 