### PR TITLE
chore: temporarily disable `build.ignore`

### DIFF
--- a/demo/netlify.toml
+++ b/demo/netlify.toml
@@ -1,8 +1,8 @@
 [build]
 command = "npm run build"
 publish = "public/"
-ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../plugin/"
 
+# ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../plugin/"
 [[plugins]]
 package = "../plugin/src/index.ts"
 


### PR DESCRIPTION
The build needs to run without `ignore` set at least once, otherwise it will keep skipping builds.