### PR TITLE
feat: add support for `/_gatsby/file/*` redirects

### DIFF
--- a/plugin/src/helpers/functions.ts
+++ b/plugin/src/helpers/functions.ts
@@ -78,11 +78,18 @@ export const setupImageCdn = async ({
     join(constants.INTERNAL_FUNCTIONS_SRC, '_ipx.ts'),
   )
 
-  netlifyConfig.redirects.push({
-    from: '/_gatsby/image/*',
-    to: '/.netlify/builders/_ipx',
-    status: 200,
-  })
+  netlifyConfig.redirects.push(
+    {
+      from: '/_gatsby/image/*',
+      to: '/.netlify/builders/_ipx',
+      status: 200,
+    },
+    {
+      from: '/_gatsby/file/*',
+      to: '/.netlify/functions/_ipx',
+      status: 200,
+    },
+  )
 }
 
 export const deleteFunctions = async ({

--- a/plugin/src/templates/ipx.ts
+++ b/plugin/src/templates/ipx.ts
@@ -1,7 +1,47 @@
+import { Buffer } from 'buffer'
+
+import { Handler, HandlerResponse } from '@netlify/functions'
 import { createIPXHandler } from '@netlify/ipx'
 
-export const handler = createIPXHandler({
+const ipxHandler = createIPXHandler({
   propsEncoding: 'base64',
   basePath: '/_gatsby/image/',
   bypassDomainCheck: true,
 })
+
+// eslint-disable-next-line require-await
+export const handler: Handler = async (event, ...rest) => {
+  const { pathname, host } = new URL(event.rawUrl)
+
+  const [, , type, encodedUrl] = pathname.split('/')
+
+  if (type === 'image') {
+    return ipxHandler(event, ...rest) as Promise<HandlerResponse>
+  }
+
+  try {
+    const urlString = Buffer.from(encodedUrl, 'base64').toString('utf8')
+    // Validate it by parsing it
+    const url = new URL(urlString)
+    if (url.host === host) {
+      return {
+        statusCode: 400,
+        body: 'File cannot be served from the same host as the original request',
+      }
+    }
+    console.log(`Redirecting to ${urlString}`)
+    return {
+      statusCode: 301,
+      headers: {
+        Location: url.toString(),
+      },
+      body: '',
+    }
+  } catch (error) {
+    console.error(error)
+    return {
+      statusCode: 400,
+      body: 'Invalid request',
+    }
+  }
+}


### PR DESCRIPTION
The Gatsby image CDN feature also supports proxying files via `/_gatsby/file/...`. Rather than proxying them, this PR implements them as a redirect for simplicity and performance.

To test, click [this link](https://deploy-preview-305--netlify-plugin-gatsby-demo.netlify.app/_gatsby/file/aHR0cHM6Ly9pbWFnZXMudW5zcGxhc2guY29tL3Bob3RvLTE1MTc4NDk4NDU1MzctNGQyNTc5MDI0NTRhP2l4bGliPXJiLTEuMi4xJml4aWQ9TW53eE1qQTNmREI4TUh4d2FHOTBieTF3WVdkbGZIeDhmR1Z1ZkRCOGZIeDgmYXV0bz1mb3JtYXQmZml0PWNyb3Amdz0yMDAwJnE9ODA=/photo-1517849845537.jpg) and check that it redirects to Unsplash: 