### PR TITLE
fix!: remove catch-all DSG redirect and handle discretely

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ manually, you have two options:
 
 You should also install the Gatsby plugin
 [gatsby-plugin-netlify](https://www.gatsbyjs.org/plugins/gatsby-plugin-netlify/).
-This is required for SSR pages, and adds support for Gatsby redirects and asset
+This is required for SSR and DSG pages, and adds support for Gatsby redirects and asset
 caching rules:
 
 1. Add the package as a dependency:

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -23,6 +23,7 @@
         "node-stream-zip": "^1.15.0",
         "pathe": "^0.2.0",
         "pretty-bytes": "^5.6.0",
+        "semver": "^7.3.5",
         "tempy": "^1.0.0"
       },
       "devDependencies": {
@@ -30,6 +31,7 @@
         "@netlify/build": "^26.5.1",
         "@types/fs-extra": "^9.0.12",
         "@types/multer": "^1.4.7",
+        "@types/semver": "^7.3.9",
         "gatsby": "^4.9.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^3.0.2",
@@ -6153,6 +6155,12 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "dev": true
+    },
+    "node_modules/@types/semver": {
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
+      "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==",
       "dev": true
     },
     "node_modules/@types/serve-static": {
@@ -29697,6 +29705,12 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "dev": true
+    },
+    "@types/semver": {
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
+      "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==",
       "dev": true
     },
     "@types/serve-static": {

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -54,6 +54,7 @@
     "node-stream-zip": "^1.15.0",
     "pathe": "^0.2.0",
     "pretty-bytes": "^5.6.0",
+    "semver": "^7.3.5",
     "tempy": "^1.0.0"
   },
   "devDependencies": {
@@ -61,6 +62,7 @@
     "@netlify/build": "^26.5.1",
     "@types/fs-extra": "^9.0.12",
     "@types/multer": "^1.4.7",
+    "@types/semver": "^7.3.9",
     "gatsby": "^4.9.0",
     "npm-run-all": "^4.1.5",
     "rimraf": "^3.0.2",

--- a/plugin/src/helpers/config.ts
+++ b/plugin/src/helpers/config.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { EOL } from 'os'
 import path from 'path'
 import process from 'process'
@@ -76,8 +77,11 @@ export async function checkConfig({ utils, netlifyConfig }): Promise<void> {
 
   if (hasPlugin(gatsbyConfig.plugins, 'gatsby-plugin-netlify')) {
     if (
-      // prettier-ignore
-      !(await checkPackageVersion(gatsbyRoot, 'gatsby-plugin-netlify', '>=4.2.0',))
+      !(await checkPackageVersion(
+        gatsbyRoot,
+        'gatsby-plugin-netlify',
+        '>=4.2.0',
+      ))
     ) {
       console.error(
         'The plugin `gatsby-plugin-netlify` does not support DSG, please update to >=4.2.0',
@@ -173,3 +177,4 @@ export function shouldSkipFunctions(cacheDir: string): boolean {
 export function getGatsbyRoot(publish: string): string {
   return path.resolve(path.dirname(publish))
 }
+/* eslint-enable max-lines */

--- a/plugin/src/helpers/files.ts
+++ b/plugin/src/helpers/files.ts
@@ -1,8 +1,16 @@
 import os from 'os'
 import process from 'process'
 
-import { copyFile, ensureDir, existsSync, readFile, writeFile } from 'fs-extra'
+import {
+  copyFile,
+  ensureDir,
+  existsSync,
+  readFile,
+  writeFile,
+  readJson,
+} from 'fs-extra'
 import { dirname, join, resolve } from 'pathe'
+import semver from 'semver'
 
 const DEFAULT_LAMBDA_PLATFORM = 'linux'
 const DEFAULT_LAMBDA_ABI = '83'
@@ -68,6 +76,26 @@ export const findModuleFromBase = ({ paths, candidates }): string | null => {
     }
   }
   return null
+}
+
+export async function checkPackageVersion(
+  root: string,
+  name: string,
+  version: string,
+): Promise<boolean> {
+  const packagePath = findModuleFromBase({
+    paths: [root],
+    candidates: [name],
+  })
+
+  let packageObj: { version: string }
+  try {
+    packageObj = await readJson(`${packagePath}/package.json`)
+  } catch {
+    return false
+  }
+
+  return semver.satisfies(packageObj.version, version)
 }
 
 /**

--- a/plugin/src/helpers/files.ts
+++ b/plugin/src/helpers/files.ts
@@ -83,19 +83,15 @@ export async function checkPackageVersion(
   name: string,
   version: string,
 ): Promise<boolean> {
-  const packagePath = findModuleFromBase({
-    paths: [root],
-    candidates: [name],
-  })
-
-  let packageObj: { version: string }
   try {
-    packageObj = await readJson(`${packagePath}/package.json`)
+    const packagePath = require.resolve(`${name}/package.json`, {
+      paths: [root],
+    })
+    const packageObj = await readJson(packagePath)
+    return semver.satisfies(packageObj.version, version)
   } catch {
     return false
   }
-
-  return semver.satisfies(packageObj.version, version)
 }
 
 /**

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -7,7 +7,7 @@ import { existsSync } from 'fs-extra'
 
 import { normalizedCacheDir, restoreCache, saveCache } from './helpers/cache'
 import {
-  checkGatsbyConfig,
+  checkConfig,
   mutateConfig,
   shouldSkipFunctions,
   spliceConfig,
@@ -32,7 +32,7 @@ export async function onPreBuild({
   }
   await restoreCache({ utils, publish: PUBLISH_DIR })
 
-  checkGatsbyConfig({ utils, netlifyConfig })
+  await checkConfig({ utils, netlifyConfig })
 }
 
 export async function onBuild({

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -79,12 +79,6 @@ The plugin no longer uses this and it should be deleted to avoid conflicts.\n`)
     contents: '/api/* /.netlify/functions/__api 200',
     fileName: join(netlifyConfig.build.publish, '_redirects'),
   })
-
-  netlifyConfig.redirects.push({
-    from: '/*',
-    to: '/.netlify/builders/__dsg',
-    status: 200,
-  })
 }
 
 export async function onPostBuild({


### PR DESCRIPTION
### Summary

BREAKING CHANGE: DSG pages are now discretely redirected to the handler function, rather than via a catch-all redirect. This PR removes the catch-all redirect and moves DSG handling to [netlify/gatsby-plugin-netlify](https://github.com/netlify/gatsby-plugin-netlify), making that plugin a requirement for DSG pages.

This change ensures that 404 pages aren't unnecessarily handled via SSR and ensures they work when a site has functions but no SSR/DSG bundle.

### Test plan

1. The demo in the repo isn't able to provide a case for 'Functions but no SSR/DSG', so a new Gatsby test site is needed with that configuration.
2. 404 page should render successfully without being redirected to the handler function.

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

Fixes #330 

![](https://www.boredpanda.com/blog/wp-content/uploads/2016/01/cute-possums-26__700.jpg)

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
