### PR TITLE
feat: enable API, SSR and DSG functions individually as required

### DIFF
--- a/plugin/src/helpers/config.ts
+++ b/plugin/src/helpers/config.ts
@@ -210,7 +210,7 @@ function shouldEnableFunctions(cacheDir: string) {
 export async function getNeededFunctions(
   cacheDir: string,
 ): Promise<FunctionList> {
-  if (shouldEnableFunctions) {
+  if (shouldEnableFunctions(cacheDir)) {
     try {
       // read skip file from gatsby-plugin-netlify
       const funcObj = await fs.readJson(

--- a/plugin/src/helpers/config.ts
+++ b/plugin/src/helpers/config.ts
@@ -159,7 +159,7 @@ export function mutateConfig({
   /* eslint-enable no-underscore-dangle, no-param-reassign */
 }
 
-function shouldSupportFunctions(cacheDir: string) {
+function shouldEnableFunctions(cacheDir: string) {
   if (
     process.env.NETLIFY_SKIP_GATSBY_FUNCTIONS === 'true' ||
     process.env.NETLIFY_SKIP_GATSBY_FUNCTIONS === '1'
@@ -183,17 +183,17 @@ function shouldSupportFunctions(cacheDir: string) {
 export async function getNeededFunctions(
   cacheDir: string,
 ): Promise<Array<string>> {
-  if (shouldSupportFunctions) {
+  if (shouldEnableFunctions) {
     try {
-      const skipReport = await fs.readJson(
+      const funcObj = await fs.readJson(
         path.join(cacheDir, '.nf-skip-gatsby-functions'),
       )
-      const funcs = Object.keys(skipReport).filter(
-        (name) => skipReport[name] === true,
+      const funcArr = Object.keys(funcObj).filter(
+        (name) => funcObj[name] === true,
       )
-      if (funcs.length !== 0) {
-        console.log(`Enabling support for ${funcs.join('/')}`)
-        return funcs
+      if (funcArr.length !== 0) {
+        console.log(`Enabling support for ${funcArr.join('/')}`)
+        return funcArr
       }
     } catch (error) {
       if (error.code === 'ENOENT') {

--- a/plugin/src/helpers/config.ts
+++ b/plugin/src/helpers/config.ts
@@ -221,27 +221,20 @@ async function readFunctionSkipFile(cacheDir: string) {
 
 // eslint-disable-next-line complexity
 function overrideNeededFunctions(neededFunctions) {
-  const skipAll =
-    process.env.NETLIFY_SKIP_GATSBY_FUNCTIONS === 'true' ||
-    process.env.NETLIFY_SKIP_GATSBY_FUNCTIONS === '1'
-
-  const skipAPI =
-    process.env.NETLIFY_SKIP_API_FUNCTION === 'true' ||
-    process.env.NETLIFY_SKIP_API_FUNCTION === '1'
-
-  const skipSSR =
-    process.env.NETLIFY_SKIP_SSR_FUNCTION === 'true' ||
-    process.env.NETLIFY_SKIP_SSR_FUNCTION === '1'
-
-  const skipDSG =
-    process.env.NETLIFY_SKIP_DSG_FUNCTION === 'true' ||
-    process.env.NETLIFY_SKIP_DSG_FUNCTION === '1'
+  const skipAll = isEnvSet('NETLIFY_SKIP_GATSBY_FUNCTIONS')
+  const skipAPI = isEnvSet('NETLIFY_SKIP_API_FUNCTION')
+  const skipSSR = isEnvSet('NETLIFY_SKIP_SSR_FUNCTION')
+  const skipDSG = isEnvSet('NETLIFY_SKIP_DSG_FUNCTION')
 
   return {
     API: skipAll || skipAPI ? false : neededFunctions.API,
     SSR: skipAll || skipSSR ? false : neededFunctions.SSR,
     DSG: skipAll || skipDSG ? false : neededFunctions.DSG,
   }
+}
+
+function isEnvSet(envVar: string) {
+  return process.env[envVar] === 'true' || process.env[envVar] === '1'
 }
 
 export function getGatsbyRoot(publish: string): string {

--- a/plugin/src/helpers/functions.ts
+++ b/plugin/src/helpers/functions.ts
@@ -6,6 +6,8 @@ import { makeApiHandler, makeHandler } from '../templates/handlers'
 
 import { getGatsbyRoot } from './config'
 
+export type FunctionList = Array<'API' | 'SSR' | 'DSG'>
+
 const writeFunction = async ({
   renderMode,
   handlerName,
@@ -38,7 +40,7 @@ export const writeFunctions = async ({
 }: {
   constants: NetlifyPluginConstants
   netlifyConfig: NetlifyConfig
-  neededFunctions: Array<string>
+  neededFunctions: FunctionList
 }): Promise<void> => {
   const { PUBLISH_DIR, INTERNAL_FUNCTIONS_SRC } = constants
   const siteRoot = getGatsbyRoot(PUBLISH_DIR)
@@ -63,8 +65,9 @@ export const writeFunctions = async ({
     })
   }
 
+  await setupImageCdn({ constants, netlifyConfig })
+
   if (neededFunctions.includes('API')) {
-    await setupImageCdn({ constants, netlifyConfig })
     await writeApiFunction({ appDir, functionDir })
   }
 }

--- a/plugin/src/helpers/functions.ts
+++ b/plugin/src/helpers/functions.ts
@@ -34,30 +34,39 @@ const writeApiFunction = async ({ appDir, functionDir }) => {
 export const writeFunctions = async ({
   constants,
   netlifyConfig,
+  neededFunctions,
 }: {
   constants: NetlifyPluginConstants
   netlifyConfig: NetlifyConfig
+  neededFunctions: Array<string>
 }): Promise<void> => {
   const { PUBLISH_DIR, INTERNAL_FUNCTIONS_SRC } = constants
   const siteRoot = getGatsbyRoot(PUBLISH_DIR)
   const functionDir = resolve(INTERNAL_FUNCTIONS_SRC, '__api')
   const appDir = relative(functionDir, siteRoot)
 
-  await writeFunction({
-    renderMode: 'SSR',
-    handlerName: '__ssr',
-    appDir,
-    functionsSrc: INTERNAL_FUNCTIONS_SRC,
-  })
+  if (neededFunctions.includes('SSR')) {
+    await writeFunction({
+      renderMode: 'SSR',
+      handlerName: '__ssr',
+      appDir,
+      functionsSrc: INTERNAL_FUNCTIONS_SRC,
+    })
+  }
 
-  await writeFunction({
-    renderMode: 'DSG',
-    handlerName: '__dsg',
-    appDir,
-    functionsSrc: INTERNAL_FUNCTIONS_SRC,
-  })
-  await setupImageCdn({ constants, netlifyConfig })
-  await writeApiFunction({ appDir, functionDir })
+  if (neededFunctions.includes('DSG')) {
+    await writeFunction({
+      renderMode: 'DSG',
+      handlerName: '__dsg',
+      appDir,
+      functionsSrc: INTERNAL_FUNCTIONS_SRC,
+    })
+  }
+
+  if (neededFunctions.includes('API')) {
+    await setupImageCdn({ constants, netlifyConfig })
+    await writeApiFunction({ appDir, functionDir })
+  }
 }
 
 export const setupImageCdn = async ({


### PR DESCRIPTION
### Summary

This PR switches `shouldSkipFunctions()` for `getNeededFunctions()` which checks the skip file generated by gatsby-plugin-netlify and returns an array of the required functions, rather than a boolean.

This array is then used throughout the remaining function setup code to enable each function individually.

Backward compatibility is maintained by disabling all functions if an empty skip file is provided and enabling all functions if no skip file exists.

The current env var `NETLIFY_SKIP_GATSBY_FUNCTIONS` still disables all functions as before, but 3 additional env vars have been added to control each function individually:

`NETLIFY_SKIP_API_FUNCTION`
`NETLIFY_SKIP_SSR_FUNCTION`
`NETLIFY_SKIP_DSG_FUNCTION`

### Test plan

* A site with no functions requirements should not generate any functions
* A site with API, SSR and DSG requirements should generate all 3 functions
* A site with API, SSR and DSG requirements, with NETLIFY_SKIP_GATSBY_FUNCTIONS = true, should not generate any functions 
* A site with only Gatsby Functions should generate the API function, but not the SSR or DSG functions

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

Fixes https://github.com/netlify/netlify-plugin-gatsby/issues/374

The additional functionality in this PR is only possible when paired with [this PR in the gatsby-plugin-repo](https://github.com/netlify/gatsby-plugin-netlify/pull/128), but the plugin still works as before without it.

![possum](https://pbs.twimg.com/media/FScSzQVWYAAc7AX?format=jpg&name=900x900)

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was
published correctly.
