### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @netlify/frameworks


### PR DESCRIPTION
Adds https://github.com/orgs/netlify/teams/frameworks as codeowner, and changes the pull request template to mention frameworks instead of integrations.

Pending adding write permissions for the frameworks team.