### PR TITLE
feat: do not pre-warm lambdas if DEPLOY_PRIME_URL is not set

### DIFF
--- a/plugin/src/helpers/config.ts
+++ b/plugin/src/helpers/config.ts
@@ -22,7 +22,10 @@ import type { FunctionList } from './functions'
  * Checks to see if GATSBY_EXCLUDE_DATASTORE_FROM_BUNDLE is enabled
  */
 export function shouldSkipBundlingDatastore(): boolean {
-  return isEnvSet('GATSBY_EXCLUDE_DATASTORE_FROM_BUNDLE')
+  return (
+    isEnvSet('GATSBY_EXCLUDE_DATASTORE_FROM_BUNDLE') &&
+    Boolean(process.env.DEPLOY_PRIME_URL)
+  )
 }
 
 export async function spliceConfig({

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -94,7 +94,7 @@ export async function onPostBuild({
 
 export async function onSuccess() {
   // Pre-warm the lambdas as downloading the datastore file can take a while
-  if (shouldSkipBundlingDatastore()) {
+  if (shouldSkipBundlingDatastore() && process.env.DEPLOY_PRIME_URL) {
     const FETCH_TIMEOUT = 5000
     const controller = new AbortController()
     const timeout = setTimeout(() => {
@@ -102,7 +102,7 @@ export async function onSuccess() {
     }, FETCH_TIMEOUT)
 
     for (const func of ['api', 'dsg', 'ssr']) {
-      const url = `${process.env.URL}/.netlify/functions/__${func}`
+      const url = `${process.env.DEPLOY_PRIME_URL}/.netlify/functions/__${func}`
       console.log(`Sending pre-warm request to: ${url}`)
 
       try {

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -94,7 +94,7 @@ export async function onPostBuild({
 
 export async function onSuccess() {
   // Pre-warm the lambdas as downloading the datastore file can take a while
-  if (shouldSkipBundlingDatastore() && process.env.DEPLOY_PRIME_URL) {
+  if (shouldSkipBundlingDatastore()) {
     const FETCH_TIMEOUT = 5000
     const controller = new AbortController()
     const timeout = setTimeout(() => {

--- a/plugin/test/helpers.js
+++ b/plugin/test/helpers.js
@@ -1,4 +1,7 @@
+const Chance = require('chance')
 const execa = require('execa')
+
+const chance = new Chance()
 
 module.exports.buildSite = async () => {
   const { exitCode, stdout, stderr } = await execa(
@@ -11,4 +14,9 @@ module.exports.buildSite = async () => {
     success: exitCode === 0,
     severityCode: exitCode,
   }
+}
+
+module.exports.enableGatsbyExcludeDatastoreFromBundle = () => {
+  process.env.GATSBY_EXCLUDE_DATASTORE_FROM_BUNDLE = 'true'
+  process.env.DEPLOY_PRIME_URL = chance.url()
 }

--- a/plugin/test/unit/index.spec.ts
+++ b/plugin/test/unit/index.spec.ts
@@ -256,7 +256,7 @@ describe('plugin', () => {
       expect(fetch).toBeCalledTimes(0)
     })
 
-    it.only('does not make requests to pre-warm the lambdas if process.env.DEPLOY_PRIME_URL is not defined', async () => {
+    it('does not make requests to pre-warm the lambdas if process.env.DEPLOY_PRIME_URL is not defined', async () => {
       delete process.env.DEPLOY_PRIME_URL
 
       await onSuccess()

--- a/plugin/test/unit/index.spec.ts
+++ b/plugin/test/unit/index.spec.ts
@@ -1,4 +1,4 @@
-/* eslint-disable max-nested-callbacks */
+/* eslint-disable max-nested-callbacks, ava/no-import-test-files */
 import process from 'process'
 
 import {
@@ -8,6 +8,7 @@ import {
 import Chance from 'chance'
 
 import { onBuild, onSuccess } from '../../src/index'
+import { enableGatsbyExcludeDatastoreFromBundle } from '../helpers'
 
 jest.mock('node-fetch', () => ({
   __esModule: true,
@@ -158,7 +159,8 @@ describe('plugin', () => {
     } = require('../../src/helpers/config')
 
     it('creates the metadata file for the Gatsby datastore when GATSBY_EXCLUDE_DATASTORE_FROM_BUNDLE is enabled', async () => {
-      process.env.GATSBY_EXCLUDE_DATASTORE_FROM_BUNDLE = 'true'
+      enableGatsbyExcludeDatastoreFromBundle()
+
       createMetadataFileAndCopyDatastore.mockImplementation(() =>
         Promise.resolve(),
       )
@@ -211,8 +213,7 @@ describe('plugin', () => {
 
     beforeEach(() => {
       fetch.mockImplementation(mockFetchMethod)
-      process.env.GATSBY_EXCLUDE_DATASTORE_FROM_BUNDLE = 'true'
-      process.env.DEPLOY_PRIME_URL = chance.url()
+      enableGatsbyExcludeDatastoreFromBundle()
     })
 
     afterEach(() => {
@@ -265,4 +266,4 @@ describe('plugin', () => {
     })
   })
 })
-/* eslint-enable max-nested-callbacks */
+/* eslint-enable max-nested-callbacks, ava/no-import-test-files */

--- a/plugin/test/unit/index.spec.ts
+++ b/plugin/test/unit/index.spec.ts
@@ -212,12 +212,12 @@ describe('plugin', () => {
     beforeEach(() => {
       fetch.mockImplementation(mockFetchMethod)
       process.env.GATSBY_EXCLUDE_DATASTORE_FROM_BUNDLE = 'true'
-      process.env.URL = chance.url()
+      process.env.DEPLOY_PRIME_URL = chance.url()
     })
 
     afterEach(() => {
       delete process.env.GATSBY_EXCLUDE_DATASTORE_FROM_BUNDLE
-      delete process.env.URL
+      delete process.env.DEPLOY_PRIME_URL
     })
 
     it('makes requests to pre-warm the lambdas if GATSBY_EXCLUDE_DATASTORE_FROM_BUNDLE is enabled', async () => {
@@ -225,17 +225,17 @@ describe('plugin', () => {
       const controller = new AbortController()
       expect(fetch).toHaveBeenNthCalledWith(
         1,
-        `${process.env.URL}/.netlify/functions/__api`,
+        `${process.env.DEPLOY_PRIME_URL}/.netlify/functions/__api`,
         { signal: controller.signal },
       )
       expect(fetch).toHaveBeenNthCalledWith(
         2,
-        `${process.env.URL}/.netlify/functions/__dsg`,
+        `${process.env.DEPLOY_PRIME_URL}/.netlify/functions/__dsg`,
         { signal: controller.signal },
       )
       expect(fetch).toHaveBeenNthCalledWith(
         3,
-        `${process.env.URL}/.netlify/functions/__ssr`,
+        `${process.env.DEPLOY_PRIME_URL}/.netlify/functions/__ssr`,
         { signal: controller.signal },
       )
     })
@@ -250,6 +250,14 @@ describe('plugin', () => {
 
     it('does not make requests to pre-warm the lambdas if process.env.GATSBY_EXCLUDE_DATASTORE_FROM_BUNDLE is not defined', async () => {
       delete process.env.GATSBY_EXCLUDE_DATASTORE_FROM_BUNDLE
+
+      await onSuccess()
+
+      expect(fetch).toBeCalledTimes(0)
+    })
+
+    it.only('does not make requests to pre-warm the lambdas if process.env.DEPLOY_PRIME_URL is not defined', async () => {
+      delete process.env.DEPLOY_PRIME_URL
 
       await onSuccess()
 

--- a/plugin/test/unit/templates/utils.spec.ts
+++ b/plugin/test/unit/templates/utils.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable ava/no-import-test-files */
 import { tmpdir } from 'os'
 import { resolve, join, dirname } from 'path'
 
@@ -14,6 +15,7 @@ import { dir as getTmpDir } from 'tmp-promise'
 
 // eslint-disable-next-line import/no-namespace
 import * as templateUtils from '../../../src/templates/utils'
+import { enableGatsbyExcludeDatastoreFromBundle } from '../../helpers'
 
 const chance = new Chance()
 const SAMPLE_PROJECT_DIR = `${__dirname}/../../../../demo`
@@ -63,7 +65,7 @@ describe('prepareFilesystem', () => {
   it(
     'downloads file from the CDN when GATSBY_EXCLUDE_DATASTORE_FROM_BUNDLE is enabled',
     async () => {
-      process.env.GATSBY_EXCLUDE_DATASTORE_FROM_BUNDLE = 'true'
+      enableGatsbyExcludeDatastoreFromBundle()
       await moveGatsbyDir()
 
       const cacheDir = resolve('.cache')
@@ -80,7 +82,7 @@ describe('prepareFilesystem', () => {
       const domain = chance.url({ path: '' })
       const url = `${domain}${chance.word()}/${chance.word()}`
 
-      process.env.GATSBY_EXCLUDE_DATASTORE_FROM_BUNDLE = 'true'
+      enableGatsbyExcludeDatastoreFromBundle()
       await moveGatsbyDir()
 
       const cacheDir = resolve('.cache')
@@ -157,3 +159,4 @@ describe('downloadFile', () => {
     )
   })
 })
+/* eslint-enable ava/no-import-test-files */


### PR DESCRIPTION
### Summary

Doesn't attempt a lambda pre-warm request if the `DEPLOY_PRIME_URL` is not set. This will address issues in our CI environment where we're attempting to make these requests for a non-existent site

### Test plan

Should see no pre-warm requests be attempted within our CI test suite, but still see them made when the `GATSBY_EXCLUDE_DATASTORE_FROM_BUNDLE` variable is set and a deploy is being made for a netlify site.

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
Fixes [this issue](https://github.com/netlify/pod-ecosystem-frameworks/issues/138)

### Standard checks:

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was
published correctly.
