### PR TITLE
test: [draft] proof of concept to improve test speed

### DIFF
--- a/plugin/test/unit/helpers/draft-config.spec.ts
+++ b/plugin/test/unit/helpers/draft-config.spec.ts
@@ -1,0 +1,172 @@
+import { resolve, join } from 'path'
+import { copySync, ensureFileSync, readdir, readJSON, writeJSON } from 'fs-extra'
+import { v4 as uuidv4 } from 'uuid'
+
+import {
+  createMetadataFileAndCopyDatastore,
+} from '../../../src/helpers/config'
+
+jest.mock('fs-extra')
+jest.mock('uuid')
+
+// TODO: Need proper TS types here!
+const mockReadJSON = readJSON as jest.MockedFunction<any>;
+const mockEnsureFileSync = ensureFileSync as jest.MockedFunction<any>
+const mockCopySync = copySync as jest.MockedFunction<any>
+const mockWriteJSON = writeJSON as jest.MockedFunction<any>
+const mockReaddir = readdir as jest.MockedFunction<any>
+const mockUuidv4 = uuidv4 as jest.MockedFunction<any>
+
+// Only added tests for 'createMetadataFileAndCopyDatastore'
+describe('createMetadataFileAndCopyDatastore', () => {
+  const mockedFileName = 'fake/path/mockFilename.mdb'
+  const mockDataMetdataJsonFile = {
+    fileName: mockedFileName
+  }
+  const publishDir = resolve('public')
+  const cacheDir = resolve('.cache')
+
+  afterEach(() => {
+    mockReadJSON.mockRestore()
+    mockEnsureFileSync.mockRestore()
+    mockCopySync.mockRestore()
+    mockWriteJSON.mockRestore()
+    mockReaddir.mockRestore()
+    mockUuidv4.mockRestore()
+  })
+
+  describe('when previous filename exists in cached metadata file', () => {
+    beforeEach(() => {
+      mockReadJSON.mockResolvedValue(mockDataMetdataJsonFile)
+    })
+
+    it('should create expected filename in published directory', async () => {
+      const expectedFileName = `${publishDir}/${mockedFileName}`
+      await createMetadataFileAndCopyDatastore(publishDir, cacheDir);
+
+      expect(mockEnsureFileSync).toHaveBeenCalledWith(expectedFileName)
+    });
+
+    it('should copy cached datastore file to published directory', async () => {
+      const expectedDataFile = join(`${cacheDir}/data/datastore/data.mdb`)
+      const expectedFileName = `${publishDir}/${mockedFileName}`
+
+      await createMetadataFileAndCopyDatastore(publishDir, cacheDir);
+
+      expect(mockCopySync).toHaveBeenCalledWith(expectedDataFile, expectedFileName)
+    })
+
+    it('should create expected metadata file in cached directory', async () => {
+      const expectedFileName = `${cacheDir}/dataMetadata.json`
+
+      await createMetadataFileAndCopyDatastore(publishDir, cacheDir);
+
+      expect(mockEnsureFileSync).toHaveBeenCalledWith(expectedFileName)
+    })
+
+    it('should write expected metadata payload in cached directory', async () => {
+      const expectedFileName = `${cacheDir}/dataMetadata.json`
+      const expectedPayload = {
+        fileName: mockedFileName
+      }
+
+      await createMetadataFileAndCopyDatastore(publishDir, cacheDir);
+
+      expect(mockWriteJSON).toHaveBeenCalledWith(expectedFileName, expectedPayload)
+    })
+  })
+
+  describe('when previous filename datastore file already exists in published directory', () => {
+    const mockedDatastoreFile = 'data-test-uuid.mdb'
+    const mockFilesInDirectory = [
+      'testFile.mdb',
+      mockedDatastoreFile
+    ]
+
+    beforeEach(() => {
+      mockReadJSON.mockResolvedValue(null)
+      mockReaddir.mockResolvedValue(mockFilesInDirectory)
+    })
+
+    it('should create expected filename in published directory', async () => {
+      const expectedFileName = `${publishDir}/${mockedDatastoreFile}`
+      await createMetadataFileAndCopyDatastore(publishDir, cacheDir);
+
+      expect(mockEnsureFileSync).toHaveBeenCalledWith(expectedFileName)
+    });
+
+    it('should copy cached datastore file to published directory', async () => {
+      const expectedDataFile = join(`${cacheDir}/data/datastore/data.mdb`)
+      const expectedFileName = `${publishDir}/${mockedDatastoreFile}`
+
+      await createMetadataFileAndCopyDatastore(publishDir, cacheDir);
+
+      expect(mockCopySync).toHaveBeenCalledWith(expectedDataFile, expectedFileName)
+    })
+
+    it('should create expected metadata file in cached directory', async () => {
+      const expectedFileName = `${cacheDir}/dataMetadata.json`
+
+      await createMetadataFileAndCopyDatastore(publishDir, cacheDir);
+
+      expect(mockEnsureFileSync).toHaveBeenCalledWith(expectedFileName)
+    })
+
+    it('should write expected metadata payload in cached directory', async () => {
+      const expectedFileName = `${cacheDir}/dataMetadata.json`
+      const expectedPayload = {
+        fileName: mockedDatastoreFile
+      }
+
+      await createMetadataFileAndCopyDatastore(publishDir, cacheDir);
+
+      expect(mockWriteJSON).toHaveBeenCalledWith(expectedFileName, expectedPayload)
+    })
+  })
+
+  describe('when previous datastore file does not exist', () => {
+    const mockedUuid = 'fake-uuid'
+    const expectedUuidFileName = `data-${mockedUuid}.mdb`
+
+    beforeEach(() => {
+      mockReadJSON.mockResolvedValue(null)
+      mockReaddir.mockResolvedValue([])
+      mockUuidv4.mockReturnValue(mockedUuid)
+    })
+
+    it('should create expected filename in published directory', async () => {
+      const expectedFileName = `${publishDir}/${expectedUuidFileName}`
+      await createMetadataFileAndCopyDatastore(publishDir, cacheDir);
+
+      expect(mockEnsureFileSync).toHaveBeenCalledWith(expectedFileName)
+    });
+
+    it('should copy cached datastore file to published directory', async () => {
+      const expectedDataFile = join(`${cacheDir}/data/datastore/data.mdb`)
+      const expectedFileName = `${publishDir}/${expectedUuidFileName}`
+
+      await createMetadataFileAndCopyDatastore(publishDir, cacheDir);
+
+      expect(mockCopySync).toHaveBeenCalledWith(expectedDataFile, expectedFileName)
+    })
+
+    it('should create expected metadata file in cached directory', async () => {
+      const expectedFileName = `${cacheDir}/dataMetadata.json`
+
+      await createMetadataFileAndCopyDatastore(publishDir, cacheDir);
+
+      expect(mockEnsureFileSync).toHaveBeenCalledWith(expectedFileName)
+    })
+
+    it('should write expected metadata payload in cached directory', async () => {
+      const expectedFileName = `${cacheDir}/dataMetadata.json`
+      const expectedPayload = {
+        fileName: expectedUuidFileName
+      }
+
+      await createMetadataFileAndCopyDatastore(publishDir, cacheDir);
+
+      expect(mockWriteJSON).toHaveBeenCalledWith(expectedFileName, expectedPayload)
+    })
+  })
+})

--- a/plugin/test/unit/helpers/draft.config.spec.ts
+++ b/plugin/test/unit/helpers/draft.config.spec.ts
@@ -95,7 +95,7 @@ describe('createMetadataFileAndCopyDatastore', () => {
     const mockFilesInDirectory = ['testFile.mdb', mockedDatastoreFile]
 
     beforeEach(() => {
-      mockReadJSON.mockResolvedValue(null)
+      mockReadJSON.mockRejectedValue(new Error('Unable to read JSON file'))
       mockReaddir.mockResolvedValue(mockFilesInDirectory)
     })
 

--- a/plugin/test/unit/helpers/draft.config.spec.ts
+++ b/plugin/test/unit/helpers/draft.config.spec.ts
@@ -1,27 +1,35 @@
+/* eslint-disable  @typescript-eslint/no-explicit-any */
 import { resolve, join } from 'path'
-import { copySync, ensureFileSync, readdir, readJSON, writeJSON } from 'fs-extra'
-import { v4 as uuidv4 } from 'uuid'
 
 import {
-  createMetadataFileAndCopyDatastore,
-} from '../../../src/helpers/config'
+  copySync,
+  ensureFileSync,
+  readdir,
+  readJSON,
+  writeJSON,
+} from 'fs-extra'
+import { v4 as uuidv4 } from 'uuid'
+
+import { createMetadataFileAndCopyDatastore } from '../../../src/helpers/config'
 
 jest.mock('fs-extra')
 jest.mock('uuid')
 
 // TODO: Need proper TS types here!
-const mockReadJSON = readJSON as jest.MockedFunction<any>;
+const mockReadJSON = readJSON as jest.MockedFunction<any>
 const mockEnsureFileSync = ensureFileSync as jest.MockedFunction<any>
 const mockCopySync = copySync as jest.MockedFunction<any>
 const mockWriteJSON = writeJSON as jest.MockedFunction<any>
 const mockReaddir = readdir as jest.MockedFunction<any>
 const mockUuidv4 = uuidv4 as jest.MockedFunction<any>
 
+/* eslint-disable max-nested-callbacks */
+/* eslint-disable max-lines-per-function */
 // Only added tests for 'createMetadataFileAndCopyDatastore'
 describe('createMetadataFileAndCopyDatastore', () => {
   const mockedFileName = 'fake/path/mockFilename.mdb'
   const mockDataMetdataJsonFile = {
-    fileName: mockedFileName
+    fileName: mockedFileName,
   }
   const publishDir = resolve('public')
   const cacheDir = resolve('.cache')
@@ -42,24 +50,27 @@ describe('createMetadataFileAndCopyDatastore', () => {
 
     it('should create expected filename in published directory', async () => {
       const expectedFileName = `${publishDir}/${mockedFileName}`
-      await createMetadataFileAndCopyDatastore(publishDir, cacheDir);
+      await createMetadataFileAndCopyDatastore(publishDir, cacheDir)
 
       expect(mockEnsureFileSync).toHaveBeenCalledWith(expectedFileName)
-    });
+    })
 
     it('should copy cached datastore file to published directory', async () => {
       const expectedDataFile = join(`${cacheDir}/data/datastore/data.mdb`)
       const expectedFileName = `${publishDir}/${mockedFileName}`
 
-      await createMetadataFileAndCopyDatastore(publishDir, cacheDir);
+      await createMetadataFileAndCopyDatastore(publishDir, cacheDir)
 
-      expect(mockCopySync).toHaveBeenCalledWith(expectedDataFile, expectedFileName)
+      expect(mockCopySync).toHaveBeenCalledWith(
+        expectedDataFile,
+        expectedFileName,
+      )
     })
 
     it('should create expected metadata file in cached directory', async () => {
       const expectedFileName = `${cacheDir}/dataMetadata.json`
 
-      await createMetadataFileAndCopyDatastore(publishDir, cacheDir);
+      await createMetadataFileAndCopyDatastore(publishDir, cacheDir)
 
       expect(mockEnsureFileSync).toHaveBeenCalledWith(expectedFileName)
     })
@@ -67,21 +78,21 @@ describe('createMetadataFileAndCopyDatastore', () => {
     it('should write expected metadata payload in cached directory', async () => {
       const expectedFileName = `${cacheDir}/dataMetadata.json`
       const expectedPayload = {
-        fileName: mockedFileName
+        fileName: mockedFileName,
       }
 
-      await createMetadataFileAndCopyDatastore(publishDir, cacheDir);
+      await createMetadataFileAndCopyDatastore(publishDir, cacheDir)
 
-      expect(mockWriteJSON).toHaveBeenCalledWith(expectedFileName, expectedPayload)
+      expect(mockWriteJSON).toHaveBeenCalledWith(
+        expectedFileName,
+        expectedPayload,
+      )
     })
   })
 
   describe('when previous filename datastore file already exists in published directory', () => {
     const mockedDatastoreFile = 'data-test-uuid.mdb'
-    const mockFilesInDirectory = [
-      'testFile.mdb',
-      mockedDatastoreFile
-    ]
+    const mockFilesInDirectory = ['testFile.mdb', mockedDatastoreFile]
 
     beforeEach(() => {
       mockReadJSON.mockResolvedValue(null)
@@ -90,24 +101,27 @@ describe('createMetadataFileAndCopyDatastore', () => {
 
     it('should create expected filename in published directory', async () => {
       const expectedFileName = `${publishDir}/${mockedDatastoreFile}`
-      await createMetadataFileAndCopyDatastore(publishDir, cacheDir);
+      await createMetadataFileAndCopyDatastore(publishDir, cacheDir)
 
       expect(mockEnsureFileSync).toHaveBeenCalledWith(expectedFileName)
-    });
+    })
 
     it('should copy cached datastore file to published directory', async () => {
       const expectedDataFile = join(`${cacheDir}/data/datastore/data.mdb`)
       const expectedFileName = `${publishDir}/${mockedDatastoreFile}`
 
-      await createMetadataFileAndCopyDatastore(publishDir, cacheDir);
+      await createMetadataFileAndCopyDatastore(publishDir, cacheDir)
 
-      expect(mockCopySync).toHaveBeenCalledWith(expectedDataFile, expectedFileName)
+      expect(mockCopySync).toHaveBeenCalledWith(
+        expectedDataFile,
+        expectedFileName,
+      )
     })
 
     it('should create expected metadata file in cached directory', async () => {
       const expectedFileName = `${cacheDir}/dataMetadata.json`
 
-      await createMetadataFileAndCopyDatastore(publishDir, cacheDir);
+      await createMetadataFileAndCopyDatastore(publishDir, cacheDir)
 
       expect(mockEnsureFileSync).toHaveBeenCalledWith(expectedFileName)
     })
@@ -115,12 +129,15 @@ describe('createMetadataFileAndCopyDatastore', () => {
     it('should write expected metadata payload in cached directory', async () => {
       const expectedFileName = `${cacheDir}/dataMetadata.json`
       const expectedPayload = {
-        fileName: mockedDatastoreFile
+        fileName: mockedDatastoreFile,
       }
 
-      await createMetadataFileAndCopyDatastore(publishDir, cacheDir);
+      await createMetadataFileAndCopyDatastore(publishDir, cacheDir)
 
-      expect(mockWriteJSON).toHaveBeenCalledWith(expectedFileName, expectedPayload)
+      expect(mockWriteJSON).toHaveBeenCalledWith(
+        expectedFileName,
+        expectedPayload,
+      )
     })
   })
 
@@ -136,24 +153,27 @@ describe('createMetadataFileAndCopyDatastore', () => {
 
     it('should create expected filename in published directory', async () => {
       const expectedFileName = `${publishDir}/${expectedUuidFileName}`
-      await createMetadataFileAndCopyDatastore(publishDir, cacheDir);
+      await createMetadataFileAndCopyDatastore(publishDir, cacheDir)
 
       expect(mockEnsureFileSync).toHaveBeenCalledWith(expectedFileName)
-    });
+    })
 
     it('should copy cached datastore file to published directory', async () => {
       const expectedDataFile = join(`${cacheDir}/data/datastore/data.mdb`)
       const expectedFileName = `${publishDir}/${expectedUuidFileName}`
 
-      await createMetadataFileAndCopyDatastore(publishDir, cacheDir);
+      await createMetadataFileAndCopyDatastore(publishDir, cacheDir)
 
-      expect(mockCopySync).toHaveBeenCalledWith(expectedDataFile, expectedFileName)
+      expect(mockCopySync).toHaveBeenCalledWith(
+        expectedDataFile,
+        expectedFileName,
+      )
     })
 
     it('should create expected metadata file in cached directory', async () => {
       const expectedFileName = `${cacheDir}/dataMetadata.json`
 
-      await createMetadataFileAndCopyDatastore(publishDir, cacheDir);
+      await createMetadataFileAndCopyDatastore(publishDir, cacheDir)
 
       expect(mockEnsureFileSync).toHaveBeenCalledWith(expectedFileName)
     })
@@ -161,12 +181,18 @@ describe('createMetadataFileAndCopyDatastore', () => {
     it('should write expected metadata payload in cached directory', async () => {
       const expectedFileName = `${cacheDir}/dataMetadata.json`
       const expectedPayload = {
-        fileName: expectedUuidFileName
+        fileName: expectedUuidFileName,
       }
 
-      await createMetadataFileAndCopyDatastore(publishDir, cacheDir);
+      await createMetadataFileAndCopyDatastore(publishDir, cacheDir)
 
-      expect(mockWriteJSON).toHaveBeenCalledWith(expectedFileName, expectedPayload)
+      expect(mockWriteJSON).toHaveBeenCalledWith(
+        expectedFileName,
+        expectedPayload,
+      )
     })
   })
 })
+/* eslint-enable max-lines-per-function */
+/* eslint-enable max-nested-callbacks */
+/* eslint-enable  @typescript-eslint/no-explicit-any */


### PR DESCRIPTION
### Summary

This is a proof of concept to rewrite the `createMetadataFileAndCopyDatastore` unit tests using mocked file operations.

Previously, the `createMetadataFileAndCopyDatastore` tests copied the whole Gatsby demo directory to a temporary folder and executed tests against them. Copying the Gatsby files and cleaning them up afterwards pushes each test to approximately 25 seconds even though the code being tested executes quickly. These execute more like end-to-end tests than unit tests.

I've added a `draft.config.spec.ts` test suite which mocks out all necessary file operations and the `uuidv4` creation. This allows us to quickly execute the tests and control the flow of necessary operations. There should be 100% test coverage of this function.

### Test plan

All tests should execute as previously but the new `draft.config.spec.ts` tests should be super speedy. 🏎️ 

**Local execution time**
| Test Suite      | Description | Execution Time |
| ----------- | ----------- | ----------- |
| `config.spec.ts` | Only `createMetadataFileAndCopyDatastore` tests enabled | **~79.544s** |
| `draft.config.spec.ts` | Only testing `createMetadataFileAndCopyDatastore`  | **~3.713s** |


### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

![image](https://user-images.githubusercontent.com/1965510/178770184-af02ac55-0552-4045-9c77-9e731ac03296.png)

