### PR TITLE
fix: add fs.promises to linked filesystem

### DIFF
--- a/plugin/src/templates/utils.ts
+++ b/plugin/src/templates/utils.ts
@@ -79,6 +79,7 @@ export async function prepareFilesystem(
   cacheDir: string,
   siteUrl: string,
 ): Promise<void> {
+  console.log('Preparing Gatsby filesystem')
   const rewrites = [
     [join(cacheDir, 'caches'), join(TEMP_CACHE_DIR, 'caches')],
     [join(cacheDir, 'caches-lmdb'), join(TEMP_CACHE_DIR, 'caches-lmdb')],

--- a/plugin/src/templates/utils.ts
+++ b/plugin/src/templates/utils.ts
@@ -79,7 +79,6 @@ export async function prepareFilesystem(
   cacheDir: string,
   siteUrl: string,
 ): Promise<void> {
-  console.log('Preparing Gatsby filesystem')
   const rewrites = [
     [join(cacheDir, 'caches'), join(TEMP_CACHE_DIR, 'caches')],
     [join(cacheDir, 'caches-lmdb'), join(TEMP_CACHE_DIR, 'caches-lmdb')],
@@ -94,6 +93,12 @@ export async function prepareFilesystem(
       lfs[key].native = fs[key].native
     }
   }
+
+  // 'promises' is not initially linked within the 'linkfs'
+  // package, and is needed by underlying Gatsby code (the
+  // @graphql-tools/code-file-loader)
+  lfs.promises = link(fs.promises, rewrites)
+
   // Gatsby uses this instead of fs if present
   // eslint-disable-next-line no-underscore-dangle
   global._fsWrapper = lfs

--- a/plugin/test/unit/templates/utils.spec.ts
+++ b/plugin/test/unit/templates/utils.spec.ts
@@ -63,6 +63,20 @@ describe('prepareFilesystem', () => {
   }, TEST_TIMEOUT)
 
   it(
+    'links fs.promises to ensure it is available on global._fsWrapper',
+    async () => {
+      await moveGatsbyDir()
+
+      const cacheDir = resolve('.cache')
+      await templateUtils.prepareFilesystem(cacheDir, chance.url())
+
+      // eslint-disable-next-line no-underscore-dangle
+      expect(global._fsWrapper.promises).toBeDefined()
+    },
+    TEST_TIMEOUT,
+  )
+
+  it(
     'downloads file from the CDN when GATSBY_EXCLUDE_DATASTORE_FROM_BUNDLE is enabled',
     async () => {
       enableGatsbyExcludeDatastoreFromBundle()


### PR DESCRIPTION
### Summary

When redirecting filesystem paths using the `linkfs` package, `fs.promises` is not included in the [redirected or proxied paths](https://github.com/streamich/linkfs/blob/50f95d1d125cede14e684457466e23434a73a0e0/src/index.ts), resulting in a "Cannot destructure property 'readFile' of 'fs_1.promises' " error on SSR pages.

This change makes `promises` is available on the global `_fsWrapper` property that is used by Gatsby. This ensures that underlying Gatsby dependencies (specifically [`graphql-tools`](https://github.com/ardatan/graphql-tools/blob/5931dc7d103ecfe16e479d652c43f0e69270d169/packages/loaders/code-file/src/index.ts#L27) in this case) have this available.

### Test plan

[Deploy preview](https://ep-gatsby-read-file-issue.netlify.app/using-ssr/) - this page should render successfully

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

Fixes https://github.com/netlify/pod-ecosystem-frameworks/issues/139
![IMG-20220713-WA0000](https://user-images.githubusercontent.com/5655473/179258009-c11e1f82-576d-4e69-96af-7b223694e01c.jpg)

