### PR TITLE
chore: fix tests to work with @netlify/build@27.20.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -446,18 +446,18 @@
       "dev": true
     },
     "@bugsnag/browser": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.17.0.tgz",
-      "integrity": "sha512-hTF1Bb62kIDN576vVw+u2m1kyT4b/1lDlAOxi5S+T1npydd+DKPQToXNbRJr29z23Ni+GG26uWA1c+rzWdYRDQ==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.18.0.tgz",
+      "integrity": "sha512-lIdM6+mazFkkPwYSbfcBDFMLJ7++WoCuWnaVeaV3HcA7V9RHC+l5CmRSEyRatsiv2xfLPAIasTxAbCCc4WPgCg==",
       "dev": true,
       "requires": {
-        "@bugsnag/core": "^7.17.0"
+        "@bugsnag/core": "^7.18.0"
       }
     },
     "@bugsnag/core": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.17.0.tgz",
-      "integrity": "sha512-qt3+Ub64tspbdb6wMiJZIOFyKGv7ZSGRa66GjBmW3Y9cTb42Y8cNx1/0hxY4cDhSbwfunGTqKCcjFRrRcTlfNA==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.18.0.tgz",
+      "integrity": "sha512-j5YVnbrQbs2WUFnhXERPm68XooUrdNrbJISsiK5+mnbWJrdGkIw8+p5sROV72fiuuQlLtV3jiEJHlSErZggLBw==",
       "dev": true,
       "requires": {
         "@bugsnag/cuid": "^3.0.0",
@@ -474,22 +474,22 @@
       "dev": true
     },
     "@bugsnag/js": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.17.0.tgz",
-      "integrity": "sha512-wBiB/4wv3X6Iw2HrU7wywGnT+tt1DfOJjTeZIcWVzJ4u9b5avx4SmvJogfHjYRV/BIZaGuG5wxZU/0NsQy429g==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.18.0.tgz",
+      "integrity": "sha512-engv7itP6E5VcqapikA/ZPgnnImxZLMRZMyu14dgld/RCjCm3XFLhGcscnN8jJkTmp366e5Xqo8Lq7y9aI6Yhw==",
       "dev": true,
       "requires": {
-        "@bugsnag/browser": "^7.17.0",
-        "@bugsnag/node": "^7.17.0"
+        "@bugsnag/browser": "^7.18.0",
+        "@bugsnag/node": "^7.18.0"
       }
     },
     "@bugsnag/node": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-7.17.0.tgz",
-      "integrity": "sha512-tTk7QMp0eKTg8p0W404xnWHsAbz+cO7wyBUwrw2FAcLYj4QIbMqz0l0hjpwN+qUl07RbCrgdKA/RWN1Evf5ziw==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-7.18.0.tgz",
+      "integrity": "sha512-jXFIJ3DF4AJZ16j5WsUF+Fe8zgtPdBOryRoqdNvTMWBHI6mVtTyn2clTPYjasocV9rdi9hC3cWxilLGlLacnaQ==",
       "dev": true,
       "requires": {
-        "@bugsnag/core": "^7.17.0",
+        "@bugsnag/core": "^7.18.0",
         "byline": "^5.0.0",
         "error-stack-parser": "^2.0.2",
         "iserror": "^0.0.2",
@@ -963,6 +963,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
+    },
+    "@import-maps/resolve": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@import-maps/resolve/-/resolve-1.0.1.tgz",
+      "integrity": "sha512-tWZNBIS1CoekcwlMuyG2mr0a1Wo5lb5lEHwwWvZo+5GLgr3e9LLDTtmgtCWEwBpXMkxn9D+2W9j2FY6eZQq0tA==",
       "dev": true
     },
     "@istanbuljs/load-nyc-config": {
@@ -2072,20 +2078,20 @@
       "dev": true
     },
     "@netlify/build": {
-      "version": "27.17.1",
-      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-27.17.1.tgz",
-      "integrity": "sha512-xN/ejCv1+IupeXp5M3frrPVjCqRmQl4J90XBxoG3go6LM2J1QyOOV6ooA5dejeQXiIQSjPK3bxR2ZEs6GwMArg==",
+      "version": "27.20.1",
+      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-27.20.1.tgz",
+      "integrity": "sha512-IjL8tQlOwrLO4fF7xqAjXUmGLyfLNETo8gftJ4qOk8CxjjNzUNbM5xt4wWv3GNScclrwAH85JXOjMnwNHXXg7w==",
       "dev": true,
       "requires": {
         "@bugsnag/js": "^7.0.0",
-        "@netlify/cache-utils": "^4.0.0",
-        "@netlify/config": "^18.2.3",
-        "@netlify/edge-bundler": "^1.14.1",
-        "@netlify/functions-utils": "^4.2.7",
-        "@netlify/git-utils": "^4.0.0",
-        "@netlify/plugins-list": "^6.41.0",
-        "@netlify/run-utils": "^4.0.0",
-        "@netlify/zip-it-and-ship-it": "^7.1.0",
+        "@netlify/cache-utils": "^4.1.5",
+        "@netlify/config": "^18.2.4",
+        "@netlify/edge-bundler": "^2.6.0",
+        "@netlify/functions-utils": "^4.2.10",
+        "@netlify/git-utils": "^4.1.2",
+        "@netlify/plugins-list": "^6.46.0",
+        "@netlify/run-utils": "^4.0.2",
+        "@netlify/zip-it-and-ship-it": "^7.1.2",
         "@sindresorhus/slugify": "^2.0.0",
         "@types/node": "^16.0.0",
         "ajv": "^8.11.0",
@@ -2196,9 +2202,9 @@
       }
     },
     "@netlify/cache-utils": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@netlify/cache-utils/-/cache-utils-4.1.4.tgz",
-      "integrity": "sha512-O31A0G5CelEAQ0ffkV6adscCP9/+0X4L3ABaxpBL02cr6XktOJd+imm+MiYF+9h/EYe8qRdwFeghjtlohXhcsQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@netlify/cache-utils/-/cache-utils-4.1.5.tgz",
+      "integrity": "sha512-NqxsL23n5LiLRnmMyAdDWhRJzuNm7OmsnWz7BhykZK2+iJ7PFeMVeZqa0tL4IQRq2JgtkWe7zCSl29035J5ctA==",
       "dev": true,
       "requires": {
         "cpy": "^8.1.0",
@@ -2213,9 +2219,9 @@
       }
     },
     "@netlify/config": {
-      "version": "18.2.3",
-      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-18.2.3.tgz",
-      "integrity": "sha512-z5pFAAVBfIvTsSv3lchfByWYNajPgiCKEbx3JkU/CtIljCtSR3f0B/GVqpHgCOJ9pfS0idVP60EhDHA2QLeUrg==",
+      "version": "18.2.4",
+      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-18.2.4.tgz",
+      "integrity": "sha512-G9YR6tAXl5FfhaoEcvAivctE3Ds7vv70GgUzJfHEcJbT6rFxSlRl+vcbX6I1TbWEucMknIifvchGTa9f0Ams8w==",
       "dev": true,
       "requires": {
         "chalk": "^5.0.0",
@@ -2306,15 +2312,18 @@
       }
     },
     "@netlify/edge-bundler": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@netlify/edge-bundler/-/edge-bundler-1.14.1.tgz",
-      "integrity": "sha512-0FJSvK5kZlf093aaWyvcULRzeUImypHn63oVsC+t8xvR08bhA9LebrYHPgQ/0GhFA8yDY+tz25xrNJ6JKKDWEw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@netlify/edge-bundler/-/edge-bundler-2.6.0.tgz",
+      "integrity": "sha512-rAfUNVmnzEhUhMw4mi8VdiNELHnS9EBSKMWPjE6YDZVXAVIhRXSO3fDlGONpYjfxirZCmKma7KXV/+TYuQXePw==",
       "dev": true,
       "requires": {
+        "@import-maps/resolve": "^1.0.1",
         "common-path-prefix": "^3.0.0",
         "del": "^6.0.0",
         "env-paths": "^3.0.0",
         "execa": "^6.0.0",
+        "find-up": "^6.3.0",
+        "get-port": "^6.1.2",
         "glob-to-regexp": "^0.4.1",
         "node-fetch": "^3.1.1",
         "node-stream-zip": "^1.15.0",
@@ -2323,7 +2332,7 @@
         "path-key": "^4.0.0",
         "semver": "^7.3.5",
         "tmp-promise": "^3.0.3",
-        "uuid": "^8.3.2"
+        "uuid": "^9.0.0"
       },
       "dependencies": {
         "execa": {
@@ -2390,174 +2399,180 @@
           "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
           "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
           "dev": true
+        },
+        "uuid": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+          "dev": true
         }
       }
     },
     "@netlify/esbuild": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild/-/esbuild-0.14.25.tgz",
-      "integrity": "sha512-ko0cMTbYpajNr0Sy6kvSqR+JDvgU/vjJhO061K1h8+Zs4MlF5AUhaITkpSOrP3g45zp++IEwN1Brxr+/BIez+g==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild/-/esbuild-0.14.39.tgz",
+      "integrity": "sha512-C3xpwdT2xw6SnSb+hLQoxjtikAKiz6BjQjzlIaysHDpGbmIcmUHZ/X+dyLtCqAvf15WNK5GSBZYOlpgcOE0WZA==",
       "dev": true,
       "requires": {
-        "@netlify/esbuild-android-64": "0.14.25",
-        "@netlify/esbuild-android-arm64": "0.14.25",
-        "@netlify/esbuild-darwin-64": "0.14.25",
-        "@netlify/esbuild-darwin-arm64": "0.14.25",
-        "@netlify/esbuild-freebsd-64": "0.14.25",
-        "@netlify/esbuild-freebsd-arm64": "0.14.25",
-        "@netlify/esbuild-linux-32": "0.14.25",
-        "@netlify/esbuild-linux-64": "0.14.25",
-        "@netlify/esbuild-linux-arm": "0.14.25",
-        "@netlify/esbuild-linux-arm64": "0.14.25",
-        "@netlify/esbuild-linux-mips64le": "0.14.25",
-        "@netlify/esbuild-linux-ppc64le": "0.14.25",
-        "@netlify/esbuild-linux-riscv64": "0.14.25",
-        "@netlify/esbuild-linux-s390x": "0.14.25",
-        "@netlify/esbuild-netbsd-64": "0.14.25",
-        "@netlify/esbuild-openbsd-64": "0.14.25",
-        "@netlify/esbuild-sunos-64": "0.14.25",
-        "@netlify/esbuild-windows-32": "0.14.25",
-        "@netlify/esbuild-windows-64": "0.14.25",
-        "@netlify/esbuild-windows-arm64": "0.14.25"
+        "@netlify/esbuild-android-64": "0.14.39",
+        "@netlify/esbuild-android-arm64": "0.14.39",
+        "@netlify/esbuild-darwin-64": "0.14.39",
+        "@netlify/esbuild-darwin-arm64": "0.14.39",
+        "@netlify/esbuild-freebsd-64": "0.14.39",
+        "@netlify/esbuild-freebsd-arm64": "0.14.39",
+        "@netlify/esbuild-linux-32": "0.14.39",
+        "@netlify/esbuild-linux-64": "0.14.39",
+        "@netlify/esbuild-linux-arm": "0.14.39",
+        "@netlify/esbuild-linux-arm64": "0.14.39",
+        "@netlify/esbuild-linux-mips64le": "0.14.39",
+        "@netlify/esbuild-linux-ppc64le": "0.14.39",
+        "@netlify/esbuild-linux-riscv64": "0.14.39",
+        "@netlify/esbuild-linux-s390x": "0.14.39",
+        "@netlify/esbuild-netbsd-64": "0.14.39",
+        "@netlify/esbuild-openbsd-64": "0.14.39",
+        "@netlify/esbuild-sunos-64": "0.14.39",
+        "@netlify/esbuild-windows-32": "0.14.39",
+        "@netlify/esbuild-windows-64": "0.14.39",
+        "@netlify/esbuild-windows-arm64": "0.14.39"
       }
     },
     "@netlify/esbuild-android-64": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-android-64/-/esbuild-android-64-0.14.25.tgz",
-      "integrity": "sha512-z8vtc3jPgQxEcW9ldN5XwEPW0BHsaNFFZ4eIYSh0D2kxTCk1K2k6PY6+9+4wsCgyY0J5fnykCEjPj9AQBzCRpg==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-android-64/-/esbuild-android-64-0.14.39.tgz",
+      "integrity": "sha512-azq+lsvjRsKLap8ubIwSJXGyknUACqYu5h98Fvyoh40Qk4QXIVKl16JIJ4s+B7jy2k9qblEc5c4nxdDA3aGbVA==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-android-arm64": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-android-arm64/-/esbuild-android-arm64-0.14.25.tgz",
-      "integrity": "sha512-M0MHkLvOsGPano1Lpbwbik09/Dku0Pl9YJKtVZimo55/pd6kUFpktUbO+VSF9gA3ihdisEkL8/Y+gc4wxLbJkg==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-android-arm64/-/esbuild-android-arm64-0.14.39.tgz",
+      "integrity": "sha512-WhIP7ePq4qMC1sxoaeB9SsJqSW6uzW7XDj/IuWl1l9r94nwxywU1sYdVLaF2mZr15njviazYjVr8x1d+ipwL3w==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-darwin-64": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-darwin-64/-/esbuild-darwin-64-0.14.25.tgz",
-      "integrity": "sha512-V1GAIfYLsCIcGfGfyAQ+VhbJ/GrzrEkMamAZd5jO1I2T1XHyPMe4vYV7W7AZzcwcYzpdlj8MXIESCODlCDXnCQ==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-darwin-64/-/esbuild-darwin-64-0.14.39.tgz",
+      "integrity": "sha512-eF4GvLYiDxtcyjFT55+h+8c8A2HltjeMezCqkt3AQSgOdu1nhlvwbBhIdg2dyM6gKEaEm5hBtTbicEDSwsLodA==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-darwin-arm64": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.25.tgz",
-      "integrity": "sha512-jfX7SY2ZD4NzSCDHZiAJfHKoqINxymToWv5LUml5/FJa6602o+x+ghg8vFezVaap1XTr+ULdFbHOEiqKpeFl+A==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.39.tgz",
+      "integrity": "sha512-b7rtnX/VtYwNbUCxs3eulrCWJ+u2YvqDcXiIV1ka+od+N0fTx+4RrVkVp1lha9L0wEJYK9J7UWZOMLMyd1ynRg==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-freebsd-64": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.25.tgz",
-      "integrity": "sha512-rsK6mW/zaFZSPVa+7CthO3bPeW6qBE9VtwHAm5tdXCP3+Qpl+9rQnbs1CEqqWGrNUv+ExlTVqrAUKkdrGq8IPg==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.39.tgz",
+      "integrity": "sha512-XtusxDJt2hUKUdggbTFolMx0kJL2zEa4STI7YwpB+ukEWoW5rODZjiLZbqqYLcjDH8k4YwHaMxs103L8eButEQ==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-freebsd-arm64": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.25.tgz",
-      "integrity": "sha512-ym2Tf0dsKWJbVu3keFSs1FZezk1PXmxckuFTr0+hJMUazeNwFqJJQrY3SiN0JM7jh+VunND2RePjfsSZpcK54g==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.39.tgz",
+      "integrity": "sha512-A9XZKai+k6kfndCtN6Dh2usT28V0+OGxzFdZsANONPQiEUTrGZCgwcHWiVlVn7SeAwPR1tKZreTnvrfj8cj7hA==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-linux-32": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-32/-/esbuild-linux-32-0.14.25.tgz",
-      "integrity": "sha512-BGRAge/+6m8/lCejgLzCdq+GpN9ah3/XBp88YGgufb4h3c2CAxrq9fIlizHyZA4THHh2T/ka3rYdBOC5ciEwEw==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-32/-/esbuild-linux-32-0.14.39.tgz",
+      "integrity": "sha512-ZQnqk/82YRvINY+aF+LlGfRZ19c5mH0jaxsO046GpIOPx6PcXHG8JJ2lg+vLJVe4zFPohxzabcYpwFuT4cg/GA==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-linux-64": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-64/-/esbuild-linux-64-0.14.25.tgz",
-      "integrity": "sha512-yD579mskxDXrDR2vC7Dw/mEFTEuQoNYBcoKsIq+ctLiyQcKI1WCgAapJ+MCNpIDkmZp4O1uVuqIiMSyoMlv1QQ==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-64/-/esbuild-linux-64-0.14.39.tgz",
+      "integrity": "sha512-IQtswVw7GAKNX/3yV390wSfSXvMWy0d5cw8csAffwBk9gupftY2lzepK4Cn6uD/aqLt3Iku33FbHop/2nPGfQA==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-linux-arm": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-arm/-/esbuild-linux-arm-0.14.25.tgz",
-      "integrity": "sha512-NtnVECEKNr53v11E4wJzQtf7oM3HSPShDZEcwadjuK85AIJpISZcc7Hi6k/g4PsSyGjp73hH8Jly2hh+o+ruvQ==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-arm/-/esbuild-linux-arm-0.14.39.tgz",
+      "integrity": "sha512-QdOzQniOed0Bz1cTC9TMMwvtAqKayYv66H4edJlbvElC81yJZF/c9XhmYWJ6P5g4nkChZubQ5RcQwTLmrFGexg==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-linux-arm64": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.25.tgz",
-      "integrity": "sha512-t1BDP9Fb94jut9m+PE4AVaTQE40JaCJEVpszvvP/6aByR5NMQ5BrNaU8e6XZ6MS7bulYsJCEcJ8I/pPraXycqg==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.39.tgz",
+      "integrity": "sha512-4Jie4QV6pWWuGN7TAshNMGbdTA9+VbRkv3rPIxhgK5gBfmsAV1yRKsumE4Y77J0AZNRiOriyoec4zc1qkmI3zg==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-linux-mips64le": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.25.tgz",
-      "integrity": "sha512-Fo5sBkAVxxy+lEmKNo1bJD1lrVI9lpdwSzXW/I8k6ly9J8Vf2JNDYgvld4GSkNVTij5jA/zuN7aSQDEoIgx4mA==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.39.tgz",
+      "integrity": "sha512-Htozxr95tw4tSd86YNbCLs1eoYQzNu/cHpzFIkuJoztZueUhl8XpRvBdob7n3kEjW1gitLWAIn8XUwSt+aJ1Tg==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-linux-ppc64le": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.25.tgz",
-      "integrity": "sha512-EDInkVpAqfyfmZtYI9g9E78ohPLtyZinR19/8PGtL4zZcRUP2AnEzQRtv4NkAKAlPGa8plv3SiGsg4qKeeYRFA==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.39.tgz",
+      "integrity": "sha512-tFy0ufWIdjeuk1rPHee00TZlhr9OSF00Ufb4ROFyt2ArKuMSkWRJuDgx6MtZcAnCIN4cybo/xWl3MKTM+scnww==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-linux-riscv64": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.25.tgz",
-      "integrity": "sha512-MACKlmgawjSkNBH34AQUNoC4CX+KD4kk5KfneiBzQeV5oUW89yBf2Q/GaqiTB58Jz93juBOkWwiV0z25AmJzvg==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.39.tgz",
+      "integrity": "sha512-ZzfKvwIxL7wQnYbVFpyNW0wotnLoKageUEM57RbjekesJoNQnqUR6Usm+LDZoB8iRsI58VX1IxnstP0cX8vOHw==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-linux-s390x": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.25.tgz",
-      "integrity": "sha512-Mti6NSFGQ6GT+C9LTn15k2JttvtMcy+c1Xxqj8GYkiOqbM7Oh6NcMlXQiHxnCCsxw5Jx0WSWjdrn/dKhdiC13A==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.39.tgz",
+      "integrity": "sha512-yjC0mFwnuMRoh0WcF0h71MF71ytZBFEQQTRdgiGT0+gbC4UApBqnTkJdLx32RscBKi9skbMChiJ748hDJou6FA==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-netbsd-64": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.25.tgz",
-      "integrity": "sha512-aNDKGpy926VcnA//hqw+d4k1q1ekpmhDdy0cuEib6ZS7Qb/5xGVRH6mjG8pf0TtonY9x+wiYNuQn4Dn/DwP9Kw==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.39.tgz",
+      "integrity": "sha512-mIq4znOoz3YfTVdv3sIWfR4Zx5JgMnT4srlhC5KYVHibhxvyDdin5txldYXmR4Zv4dZd6DSuWFsn441aUegHeA==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-openbsd-64": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.25.tgz",
-      "integrity": "sha512-70W5TnRX5MroXVN0munWpF5q/AAWlamoy+PUL6cnDgc7cfnRiHHrndY++ZpWczNif8t4fQKVtC4jdUemnyb8Ag==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.39.tgz",
+      "integrity": "sha512-+t6QdzJCngH19hV7ClpFAeFDI2ko/HNcFbiNwaXTMVLB3hWi1sJtn+fzZck5HfzN4qsajAVqZq4nwX69SSt25A==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-sunos-64": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-sunos-64/-/esbuild-sunos-64-0.14.25.tgz",
-      "integrity": "sha512-UImichNlQInjErof7tuoG/8VVbrn8Y5EVVMI4M+RoCafWh9NSl4a57hohcgwbeGwl5NcGJtHg+l/WqzlHQFFsQ==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-sunos-64/-/esbuild-sunos-64-0.14.39.tgz",
+      "integrity": "sha512-HLfXG6i2p3wyyyWHeeP4ShGDJ1zRMnf9YLJLe2ezv2KqvcKw/Un/m/FBuDW1p13oSUO7ShISMzgc1dw1GGBEOQ==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-windows-32": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-windows-32/-/esbuild-windows-32-0.14.25.tgz",
-      "integrity": "sha512-OFisPQBbuIH8wMRm//fs7wQ7d6t1PuLylIUsUSgignjEV3BOts4+pjtq0J8Aq9kkKoVp8HGSJjaxpc6v2ER/KA==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-windows-32/-/esbuild-windows-32-0.14.39.tgz",
+      "integrity": "sha512-ZpSQcKbVSCU3ln7mHpsL/5dWsUqCNdTnC5YAArnaOwdrlIunrsbo5j4MOZRRcGExb2uvTc/rb+D3mlGb8j1rkA==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-windows-64": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-windows-64/-/esbuild-windows-64-0.14.25.tgz",
-      "integrity": "sha512-BgIxcEcqr4pfRc9fXStIXQVpjIkBUc3XHFEjH2t2R9pcEDU4BpMsdBgj0UA2x3Z0KtwVLLCOZDvSiaL+WkiTqA==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-windows-64/-/esbuild-windows-64-0.14.39.tgz",
+      "integrity": "sha512-I3gCdO8+6IDhT4Y1ZmV4o2Gg0oELv7N4kCcE4kqclz10fWHNjf19HQNHyBJe0AWnFV5ZfT154VVD31dqgwpgFw==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-windows-arm64": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.25.tgz",
-      "integrity": "sha512-B5Neu8aXqucUthCvAwVX7IvKbNSD/n3VFiQQcH0YQ+mtbzEIRIFaEAIanGdkmLx0shVBOlY9JxIeRThGPt2/2A==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.39.tgz",
+      "integrity": "sha512-WX52W8U1lsfWcz6NWoSpDs57lgiiMHN23seq8G2bvxzGS/tvYD3dxVLLW5UPoKSnFDyVQT7b6Zkt6AkBten1yQ==",
       "dev": true,
       "optional": true
     },
@@ -2662,20 +2677,20 @@
       }
     },
     "@netlify/functions-utils": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@netlify/functions-utils/-/functions-utils-4.2.7.tgz",
-      "integrity": "sha512-A5zwQFnuvvdHFzrKKT3SbYDACWucP5fXb2Qjo1U4dTWMjeOOyqNONxmtP91LbWTG3gYIVCafYZXq8VBIF5sPGQ==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@netlify/functions-utils/-/functions-utils-4.2.10.tgz",
+      "integrity": "sha512-OodKCe8fmD/uK3sGkfcBi6bwOuM/V1/gMf//67/4HkIUj1haaEICcJmpw17r7RwyseIwOEvdBV5oHEmSyOhDhA==",
       "dev": true,
       "requires": {
-        "@netlify/zip-it-and-ship-it": "^7.1.0",
+        "@netlify/zip-it-and-ship-it": "^7.1.2",
         "cpy": "^8.1.0",
         "path-exists": "^5.0.0"
       }
     },
     "@netlify/git-utils": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@netlify/git-utils/-/git-utils-4.1.1.tgz",
-      "integrity": "sha512-nErJowHlUHd36R/1KsXFEh9a5VL98/fr/IjwealZRQK+2E4Pm9t/KBkvR+LAyqWoINrrtkbpwjBRnO4r034OUg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@netlify/git-utils/-/git-utils-4.1.2.tgz",
+      "integrity": "sha512-Eee5Ht/bHPUV1cGaPF7kqV5V/78cXX0qyVDRDY72Crouw1F7V7D42yWpyf7/HrIg87LdzYoTmNwff7LMUTG4QA==",
       "dev": true,
       "requires": {
         "execa": "^6.0.0",
@@ -2753,15 +2768,15 @@
       "dev": true
     },
     "@netlify/plugins-list": {
-      "version": "6.41.0",
-      "resolved": "https://registry.npmjs.org/@netlify/plugins-list/-/plugins-list-6.41.0.tgz",
-      "integrity": "sha512-WUXn1kk1oDumzYKQVAf3Z5xQkVuHyR6k+LGt2qq6rFlxILmFA3gWMSf+AwVfT2bYK8gHWcdz2I9MSo5hbp1ohQ==",
+      "version": "6.46.0",
+      "resolved": "https://registry.npmjs.org/@netlify/plugins-list/-/plugins-list-6.46.0.tgz",
+      "integrity": "sha512-kUX90Eacqko9ni3cepVZKXFTLmhdwES/HDRlMYxyUh+SmvXWRC+h43b11nA0/6M5PEPolUChQOZN9wZql6oJJw==",
       "dev": true
     },
     "@netlify/run-utils": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@netlify/run-utils/-/run-utils-4.0.1.tgz",
-      "integrity": "sha512-6xwmYJWcQkRTdtA/u6WFRYBTuU7j9j+lh7Ld2+6TsUricnyg4orMIKQBdmVYM3tGbzzAidTOjzmbc8XXzQOo6g==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@netlify/run-utils/-/run-utils-4.0.2.tgz",
+      "integrity": "sha512-UH7AIkZ0TDOj6u2Kf+cTGNlM4twMV43AjJnVCdnUXBzZmFlV6p9ymwu7GYM33iXsid8i6cDBhRWQ03HcfPssIQ==",
       "dev": true,
       "requires": {
         "execa": "^6.0.0"
@@ -2829,14 +2844,14 @@
       }
     },
     "@netlify/zip-it-and-ship-it": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-7.1.0.tgz",
-      "integrity": "sha512-9kERr20cdfdiHyNGnUZih3vBEBnVTNlkxDWzD5y6XyXepGxifnxfThsAARLR8gr3DrwFzvsIgZaMbCtGE2JMow==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-7.1.2.tgz",
+      "integrity": "sha512-WGCt5KDk5Zr+A0fhPGEgAAW2aNiGyLcZohBq4nu/4BoFtHkk+8vCZOH1lMytZiIFu0eAq00j2q4kdzyLFV0Wuw==",
       "dev": true,
       "requires": {
         "@babel/parser": "7.16.8",
         "@netlify/binary-info": "^1.0.0",
-        "@netlify/esbuild": "0.14.25",
+        "@netlify/esbuild": "0.14.39",
         "@vercel/nft": "^0.22.0",
         "archiver": "^5.3.0",
         "common-path-prefix": "^3.0.0",
@@ -3316,12 +3331,12 @@
       "dev": true
     },
     "@types/responselike": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-3.0.0.tgz",
-      "integrity": "sha512-zfgGLWx5IQOTJgQPD4UfGEhapTKUPC1ra/QCG02y3GUJWrhX05bBf/EfTh3aFj2DKi7cLo+cipXLNclD27tQXQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
       "dev": true,
       "requires": {
-        "responselike": "*"
+        "@types/node": "*"
       }
     },
     "@types/retry": {
@@ -4854,9 +4869,9 @@
       }
     },
     "commander": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
-      "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
+      "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
       "dev": true
     },
     "common-path-prefix": {
@@ -7562,6 +7577,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true
+    },
+    "get-port": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-6.1.2.tgz",
+      "integrity": "sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw==",
       "dev": true
     },
     "get-stream": {
@@ -11032,9 +11053,9 @@
       }
     },
     "luxon": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.3.tgz",
-      "integrity": "sha512-+EfHWnF+UT7GgTnq5zXg3ldnTKL2zdv7QJgsU5bjjpbH17E3qi/puMhQyJVYuCq+FRkogvB5WB6iVvUr+E4a7w==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.4.tgz",
+      "integrity": "sha512-aV48rGUwP/Vydn8HT+5cdr26YYQiUZ42NM6ToMoaGKwYfWbfLeRkEu1wXWMHBZT6+KyLfcbbtVcoQFCbbPjKlw==",
       "dev": true
     },
     "macos-release": {
@@ -12549,9 +12570,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
-      "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+      "version": "8.4.17",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.17.tgz",
+      "integrity": "sha512-UNxNOLQydcOFi41yHNMcKRZ39NeXlr8AxGuZJsdub8vIb12fHzcq37DTU/QtbI6WLxNg2gF9Z+8qtRwTj1UI1Q==",
       "dev": true,
       "requires": {
         "nanoid": "^3.3.4",
@@ -13744,9 +13765,9 @@
       }
     },
     "supports-color": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.2.2.tgz",
-      "integrity": "sha512-XC6g/Kgux+rJXmwokjm9ECpD6k/smUoS5LKlUCcsYr4IY3rW0XyAympon2RmxGrlnZURMpg5T18gWDP9CsHXFA==",
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.2.3.tgz",
+      "integrity": "sha512-aszYUX/DVK/ed5rFLb/dDinVJrQjG/vmU433wtqVSD800rYsJNWxh2R3USV90aLSU+UsyQkbNeffVLzc6B6foA==",
       "dev": true
     },
     "supports-hyperlinks": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "prettier": "--loglevel=warn \"{plugin,demo,.github}/**/*.{ts,js,md,yml,json,html}\" \"*.{ts,js,yml,json,html}\" \".*.{ts,js,yml,json,html}\" \"!package-lock.json\""
   },
   "devDependencies": {
-    "@netlify/build": "^27.17.1",
+    "@netlify/build": "^27.20.1",
     "@netlify/eslint-config-node": "7.0.0",
     "@types/jest": "^28.0.0",
     "ava": "^4.0.0",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1836,18 +1836,18 @@
       }
     },
     "@bugsnag/browser": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.17.0.tgz",
-      "integrity": "sha512-hTF1Bb62kIDN576vVw+u2m1kyT4b/1lDlAOxi5S+T1npydd+DKPQToXNbRJr29z23Ni+GG26uWA1c+rzWdYRDQ==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.18.0.tgz",
+      "integrity": "sha512-lIdM6+mazFkkPwYSbfcBDFMLJ7++WoCuWnaVeaV3HcA7V9RHC+l5CmRSEyRatsiv2xfLPAIasTxAbCCc4WPgCg==",
       "dev": true,
       "requires": {
-        "@bugsnag/core": "^7.17.0"
+        "@bugsnag/core": "^7.18.0"
       }
     },
     "@bugsnag/core": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.17.0.tgz",
-      "integrity": "sha512-qt3+Ub64tspbdb6wMiJZIOFyKGv7ZSGRa66GjBmW3Y9cTb42Y8cNx1/0hxY4cDhSbwfunGTqKCcjFRrRcTlfNA==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.18.0.tgz",
+      "integrity": "sha512-j5YVnbrQbs2WUFnhXERPm68XooUrdNrbJISsiK5+mnbWJrdGkIw8+p5sROV72fiuuQlLtV3jiEJHlSErZggLBw==",
       "dev": true,
       "requires": {
         "@bugsnag/cuid": "^3.0.0",
@@ -1864,22 +1864,22 @@
       "dev": true
     },
     "@bugsnag/js": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.17.0.tgz",
-      "integrity": "sha512-wBiB/4wv3X6Iw2HrU7wywGnT+tt1DfOJjTeZIcWVzJ4u9b5avx4SmvJogfHjYRV/BIZaGuG5wxZU/0NsQy429g==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.18.0.tgz",
+      "integrity": "sha512-engv7itP6E5VcqapikA/ZPgnnImxZLMRZMyu14dgld/RCjCm3XFLhGcscnN8jJkTmp366e5Xqo8Lq7y9aI6Yhw==",
       "dev": true,
       "requires": {
-        "@bugsnag/browser": "^7.17.0",
-        "@bugsnag/node": "^7.17.0"
+        "@bugsnag/browser": "^7.18.0",
+        "@bugsnag/node": "^7.18.0"
       }
     },
     "@bugsnag/node": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-7.17.0.tgz",
-      "integrity": "sha512-tTk7QMp0eKTg8p0W404xnWHsAbz+cO7wyBUwrw2FAcLYj4QIbMqz0l0hjpwN+qUl07RbCrgdKA/RWN1Evf5ziw==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-7.18.0.tgz",
+      "integrity": "sha512-jXFIJ3DF4AJZ16j5WsUF+Fe8zgtPdBOryRoqdNvTMWBHI6mVtTyn2clTPYjasocV9rdi9hC3cWxilLGlLacnaQ==",
       "dev": true,
       "requires": {
-        "@bugsnag/core": "^7.17.0",
+        "@bugsnag/core": "^7.18.0",
         "byline": "^5.0.0",
         "error-stack-parser": "^2.0.2",
         "iserror": "^0.0.2",
@@ -2299,6 +2299,12 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "@import-maps/resolve": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@import-maps/resolve/-/resolve-1.0.1.tgz",
+      "integrity": "sha512-tWZNBIS1CoekcwlMuyG2mr0a1Wo5lb5lEHwwWvZo+5GLgr3e9LLDTtmgtCWEwBpXMkxn9D+2W9j2FY6eZQq0tA==",
+      "dev": true
+    },
     "@jest/types": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
@@ -2525,20 +2531,20 @@
       "dev": true
     },
     "@netlify/build": {
-      "version": "27.17.1",
-      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-27.17.1.tgz",
-      "integrity": "sha512-xN/ejCv1+IupeXp5M3frrPVjCqRmQl4J90XBxoG3go6LM2J1QyOOV6ooA5dejeQXiIQSjPK3bxR2ZEs6GwMArg==",
+      "version": "27.20.1",
+      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-27.20.1.tgz",
+      "integrity": "sha512-IjL8tQlOwrLO4fF7xqAjXUmGLyfLNETo8gftJ4qOk8CxjjNzUNbM5xt4wWv3GNScclrwAH85JXOjMnwNHXXg7w==",
       "dev": true,
       "requires": {
         "@bugsnag/js": "^7.0.0",
-        "@netlify/cache-utils": "^4.0.0",
-        "@netlify/config": "^18.2.3",
-        "@netlify/edge-bundler": "^1.14.1",
-        "@netlify/functions-utils": "^4.2.7",
-        "@netlify/git-utils": "^4.0.0",
-        "@netlify/plugins-list": "^6.41.0",
-        "@netlify/run-utils": "^4.0.0",
-        "@netlify/zip-it-and-ship-it": "^7.1.0",
+        "@netlify/cache-utils": "^4.1.5",
+        "@netlify/config": "^18.2.4",
+        "@netlify/edge-bundler": "^2.6.0",
+        "@netlify/functions-utils": "^4.2.10",
+        "@netlify/git-utils": "^4.1.2",
+        "@netlify/plugins-list": "^6.46.0",
+        "@netlify/run-utils": "^4.0.2",
+        "@netlify/zip-it-and-ship-it": "^7.1.2",
         "@sindresorhus/slugify": "^2.0.0",
         "@types/node": "^16.0.0",
         "ajv": "^8.11.0",
@@ -2673,9 +2679,9 @@
       }
     },
     "@netlify/cache-utils": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@netlify/cache-utils/-/cache-utils-4.1.4.tgz",
-      "integrity": "sha512-O31A0G5CelEAQ0ffkV6adscCP9/+0X4L3ABaxpBL02cr6XktOJd+imm+MiYF+9h/EYe8qRdwFeghjtlohXhcsQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@netlify/cache-utils/-/cache-utils-4.1.5.tgz",
+      "integrity": "sha512-NqxsL23n5LiLRnmMyAdDWhRJzuNm7OmsnWz7BhykZK2+iJ7PFeMVeZqa0tL4IQRq2JgtkWe7zCSl29035J5ctA==",
       "dev": true,
       "requires": {
         "cpy": "^8.1.0",
@@ -2690,9 +2696,9 @@
       }
     },
     "@netlify/config": {
-      "version": "18.2.3",
-      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-18.2.3.tgz",
-      "integrity": "sha512-z5pFAAVBfIvTsSv3lchfByWYNajPgiCKEbx3JkU/CtIljCtSR3f0B/GVqpHgCOJ9pfS0idVP60EhDHA2QLeUrg==",
+      "version": "18.2.4",
+      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-18.2.4.tgz",
+      "integrity": "sha512-G9YR6tAXl5FfhaoEcvAivctE3Ds7vv70GgUzJfHEcJbT6rFxSlRl+vcbX6I1TbWEucMknIifvchGTa9f0Ams8w==",
       "dev": true,
       "requires": {
         "chalk": "^5.0.0",
@@ -2789,15 +2795,18 @@
       }
     },
     "@netlify/edge-bundler": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@netlify/edge-bundler/-/edge-bundler-1.14.1.tgz",
-      "integrity": "sha512-0FJSvK5kZlf093aaWyvcULRzeUImypHn63oVsC+t8xvR08bhA9LebrYHPgQ/0GhFA8yDY+tz25xrNJ6JKKDWEw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@netlify/edge-bundler/-/edge-bundler-2.6.0.tgz",
+      "integrity": "sha512-rAfUNVmnzEhUhMw4mi8VdiNELHnS9EBSKMWPjE6YDZVXAVIhRXSO3fDlGONpYjfxirZCmKma7KXV/+TYuQXePw==",
       "dev": true,
       "requires": {
+        "@import-maps/resolve": "^1.0.1",
         "common-path-prefix": "^3.0.0",
         "del": "^6.0.0",
         "env-paths": "^3.0.0",
         "execa": "^6.0.0",
+        "find-up": "^6.3.0",
+        "get-port": "^6.1.2",
         "glob-to-regexp": "^0.4.1",
         "node-fetch": "^3.1.1",
         "node-stream-zip": "^1.15.0",
@@ -2806,7 +2815,7 @@
         "path-key": "^4.0.0",
         "semver": "^7.3.5",
         "tmp-promise": "^3.0.3",
-        "uuid": "^8.3.2"
+        "uuid": "^9.0.0"
       },
       "dependencies": {
         "execa": {
@@ -2825,6 +2834,12 @@
             "signal-exit": "^3.0.7",
             "strip-final-newline": "^3.0.0"
           }
+        },
+        "get-port": {
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/get-port/-/get-port-6.1.2.tgz",
+          "integrity": "sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw==",
+          "dev": true
         },
         "human-signals": {
           "version": "3.0.1",
@@ -2878,174 +2893,180 @@
           "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
           "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
           "dev": true
+        },
+        "uuid": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+          "dev": true
         }
       }
     },
     "@netlify/esbuild": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild/-/esbuild-0.14.25.tgz",
-      "integrity": "sha512-ko0cMTbYpajNr0Sy6kvSqR+JDvgU/vjJhO061K1h8+Zs4MlF5AUhaITkpSOrP3g45zp++IEwN1Brxr+/BIez+g==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild/-/esbuild-0.14.39.tgz",
+      "integrity": "sha512-C3xpwdT2xw6SnSb+hLQoxjtikAKiz6BjQjzlIaysHDpGbmIcmUHZ/X+dyLtCqAvf15WNK5GSBZYOlpgcOE0WZA==",
       "dev": true,
       "requires": {
-        "@netlify/esbuild-android-64": "0.14.25",
-        "@netlify/esbuild-android-arm64": "0.14.25",
-        "@netlify/esbuild-darwin-64": "0.14.25",
-        "@netlify/esbuild-darwin-arm64": "0.14.25",
-        "@netlify/esbuild-freebsd-64": "0.14.25",
-        "@netlify/esbuild-freebsd-arm64": "0.14.25",
-        "@netlify/esbuild-linux-32": "0.14.25",
-        "@netlify/esbuild-linux-64": "0.14.25",
-        "@netlify/esbuild-linux-arm": "0.14.25",
-        "@netlify/esbuild-linux-arm64": "0.14.25",
-        "@netlify/esbuild-linux-mips64le": "0.14.25",
-        "@netlify/esbuild-linux-ppc64le": "0.14.25",
-        "@netlify/esbuild-linux-riscv64": "0.14.25",
-        "@netlify/esbuild-linux-s390x": "0.14.25",
-        "@netlify/esbuild-netbsd-64": "0.14.25",
-        "@netlify/esbuild-openbsd-64": "0.14.25",
-        "@netlify/esbuild-sunos-64": "0.14.25",
-        "@netlify/esbuild-windows-32": "0.14.25",
-        "@netlify/esbuild-windows-64": "0.14.25",
-        "@netlify/esbuild-windows-arm64": "0.14.25"
+        "@netlify/esbuild-android-64": "0.14.39",
+        "@netlify/esbuild-android-arm64": "0.14.39",
+        "@netlify/esbuild-darwin-64": "0.14.39",
+        "@netlify/esbuild-darwin-arm64": "0.14.39",
+        "@netlify/esbuild-freebsd-64": "0.14.39",
+        "@netlify/esbuild-freebsd-arm64": "0.14.39",
+        "@netlify/esbuild-linux-32": "0.14.39",
+        "@netlify/esbuild-linux-64": "0.14.39",
+        "@netlify/esbuild-linux-arm": "0.14.39",
+        "@netlify/esbuild-linux-arm64": "0.14.39",
+        "@netlify/esbuild-linux-mips64le": "0.14.39",
+        "@netlify/esbuild-linux-ppc64le": "0.14.39",
+        "@netlify/esbuild-linux-riscv64": "0.14.39",
+        "@netlify/esbuild-linux-s390x": "0.14.39",
+        "@netlify/esbuild-netbsd-64": "0.14.39",
+        "@netlify/esbuild-openbsd-64": "0.14.39",
+        "@netlify/esbuild-sunos-64": "0.14.39",
+        "@netlify/esbuild-windows-32": "0.14.39",
+        "@netlify/esbuild-windows-64": "0.14.39",
+        "@netlify/esbuild-windows-arm64": "0.14.39"
       }
     },
     "@netlify/esbuild-android-64": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-android-64/-/esbuild-android-64-0.14.25.tgz",
-      "integrity": "sha512-z8vtc3jPgQxEcW9ldN5XwEPW0BHsaNFFZ4eIYSh0D2kxTCk1K2k6PY6+9+4wsCgyY0J5fnykCEjPj9AQBzCRpg==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-android-64/-/esbuild-android-64-0.14.39.tgz",
+      "integrity": "sha512-azq+lsvjRsKLap8ubIwSJXGyknUACqYu5h98Fvyoh40Qk4QXIVKl16JIJ4s+B7jy2k9qblEc5c4nxdDA3aGbVA==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-android-arm64": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-android-arm64/-/esbuild-android-arm64-0.14.25.tgz",
-      "integrity": "sha512-M0MHkLvOsGPano1Lpbwbik09/Dku0Pl9YJKtVZimo55/pd6kUFpktUbO+VSF9gA3ihdisEkL8/Y+gc4wxLbJkg==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-android-arm64/-/esbuild-android-arm64-0.14.39.tgz",
+      "integrity": "sha512-WhIP7ePq4qMC1sxoaeB9SsJqSW6uzW7XDj/IuWl1l9r94nwxywU1sYdVLaF2mZr15njviazYjVr8x1d+ipwL3w==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-darwin-64": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-darwin-64/-/esbuild-darwin-64-0.14.25.tgz",
-      "integrity": "sha512-V1GAIfYLsCIcGfGfyAQ+VhbJ/GrzrEkMamAZd5jO1I2T1XHyPMe4vYV7W7AZzcwcYzpdlj8MXIESCODlCDXnCQ==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-darwin-64/-/esbuild-darwin-64-0.14.39.tgz",
+      "integrity": "sha512-eF4GvLYiDxtcyjFT55+h+8c8A2HltjeMezCqkt3AQSgOdu1nhlvwbBhIdg2dyM6gKEaEm5hBtTbicEDSwsLodA==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-darwin-arm64": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.25.tgz",
-      "integrity": "sha512-jfX7SY2ZD4NzSCDHZiAJfHKoqINxymToWv5LUml5/FJa6602o+x+ghg8vFezVaap1XTr+ULdFbHOEiqKpeFl+A==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.39.tgz",
+      "integrity": "sha512-b7rtnX/VtYwNbUCxs3eulrCWJ+u2YvqDcXiIV1ka+od+N0fTx+4RrVkVp1lha9L0wEJYK9J7UWZOMLMyd1ynRg==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-freebsd-64": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.25.tgz",
-      "integrity": "sha512-rsK6mW/zaFZSPVa+7CthO3bPeW6qBE9VtwHAm5tdXCP3+Qpl+9rQnbs1CEqqWGrNUv+ExlTVqrAUKkdrGq8IPg==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.39.tgz",
+      "integrity": "sha512-XtusxDJt2hUKUdggbTFolMx0kJL2zEa4STI7YwpB+ukEWoW5rODZjiLZbqqYLcjDH8k4YwHaMxs103L8eButEQ==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-freebsd-arm64": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.25.tgz",
-      "integrity": "sha512-ym2Tf0dsKWJbVu3keFSs1FZezk1PXmxckuFTr0+hJMUazeNwFqJJQrY3SiN0JM7jh+VunND2RePjfsSZpcK54g==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.39.tgz",
+      "integrity": "sha512-A9XZKai+k6kfndCtN6Dh2usT28V0+OGxzFdZsANONPQiEUTrGZCgwcHWiVlVn7SeAwPR1tKZreTnvrfj8cj7hA==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-linux-32": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-32/-/esbuild-linux-32-0.14.25.tgz",
-      "integrity": "sha512-BGRAge/+6m8/lCejgLzCdq+GpN9ah3/XBp88YGgufb4h3c2CAxrq9fIlizHyZA4THHh2T/ka3rYdBOC5ciEwEw==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-32/-/esbuild-linux-32-0.14.39.tgz",
+      "integrity": "sha512-ZQnqk/82YRvINY+aF+LlGfRZ19c5mH0jaxsO046GpIOPx6PcXHG8JJ2lg+vLJVe4zFPohxzabcYpwFuT4cg/GA==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-linux-64": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-64/-/esbuild-linux-64-0.14.25.tgz",
-      "integrity": "sha512-yD579mskxDXrDR2vC7Dw/mEFTEuQoNYBcoKsIq+ctLiyQcKI1WCgAapJ+MCNpIDkmZp4O1uVuqIiMSyoMlv1QQ==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-64/-/esbuild-linux-64-0.14.39.tgz",
+      "integrity": "sha512-IQtswVw7GAKNX/3yV390wSfSXvMWy0d5cw8csAffwBk9gupftY2lzepK4Cn6uD/aqLt3Iku33FbHop/2nPGfQA==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-linux-arm": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-arm/-/esbuild-linux-arm-0.14.25.tgz",
-      "integrity": "sha512-NtnVECEKNr53v11E4wJzQtf7oM3HSPShDZEcwadjuK85AIJpISZcc7Hi6k/g4PsSyGjp73hH8Jly2hh+o+ruvQ==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-arm/-/esbuild-linux-arm-0.14.39.tgz",
+      "integrity": "sha512-QdOzQniOed0Bz1cTC9TMMwvtAqKayYv66H4edJlbvElC81yJZF/c9XhmYWJ6P5g4nkChZubQ5RcQwTLmrFGexg==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-linux-arm64": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.25.tgz",
-      "integrity": "sha512-t1BDP9Fb94jut9m+PE4AVaTQE40JaCJEVpszvvP/6aByR5NMQ5BrNaU8e6XZ6MS7bulYsJCEcJ8I/pPraXycqg==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.39.tgz",
+      "integrity": "sha512-4Jie4QV6pWWuGN7TAshNMGbdTA9+VbRkv3rPIxhgK5gBfmsAV1yRKsumE4Y77J0AZNRiOriyoec4zc1qkmI3zg==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-linux-mips64le": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.25.tgz",
-      "integrity": "sha512-Fo5sBkAVxxy+lEmKNo1bJD1lrVI9lpdwSzXW/I8k6ly9J8Vf2JNDYgvld4GSkNVTij5jA/zuN7aSQDEoIgx4mA==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.39.tgz",
+      "integrity": "sha512-Htozxr95tw4tSd86YNbCLs1eoYQzNu/cHpzFIkuJoztZueUhl8XpRvBdob7n3kEjW1gitLWAIn8XUwSt+aJ1Tg==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-linux-ppc64le": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.25.tgz",
-      "integrity": "sha512-EDInkVpAqfyfmZtYI9g9E78ohPLtyZinR19/8PGtL4zZcRUP2AnEzQRtv4NkAKAlPGa8plv3SiGsg4qKeeYRFA==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.39.tgz",
+      "integrity": "sha512-tFy0ufWIdjeuk1rPHee00TZlhr9OSF00Ufb4ROFyt2ArKuMSkWRJuDgx6MtZcAnCIN4cybo/xWl3MKTM+scnww==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-linux-riscv64": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.25.tgz",
-      "integrity": "sha512-MACKlmgawjSkNBH34AQUNoC4CX+KD4kk5KfneiBzQeV5oUW89yBf2Q/GaqiTB58Jz93juBOkWwiV0z25AmJzvg==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.39.tgz",
+      "integrity": "sha512-ZzfKvwIxL7wQnYbVFpyNW0wotnLoKageUEM57RbjekesJoNQnqUR6Usm+LDZoB8iRsI58VX1IxnstP0cX8vOHw==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-linux-s390x": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.25.tgz",
-      "integrity": "sha512-Mti6NSFGQ6GT+C9LTn15k2JttvtMcy+c1Xxqj8GYkiOqbM7Oh6NcMlXQiHxnCCsxw5Jx0WSWjdrn/dKhdiC13A==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.39.tgz",
+      "integrity": "sha512-yjC0mFwnuMRoh0WcF0h71MF71ytZBFEQQTRdgiGT0+gbC4UApBqnTkJdLx32RscBKi9skbMChiJ748hDJou6FA==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-netbsd-64": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.25.tgz",
-      "integrity": "sha512-aNDKGpy926VcnA//hqw+d4k1q1ekpmhDdy0cuEib6ZS7Qb/5xGVRH6mjG8pf0TtonY9x+wiYNuQn4Dn/DwP9Kw==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.39.tgz",
+      "integrity": "sha512-mIq4znOoz3YfTVdv3sIWfR4Zx5JgMnT4srlhC5KYVHibhxvyDdin5txldYXmR4Zv4dZd6DSuWFsn441aUegHeA==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-openbsd-64": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.25.tgz",
-      "integrity": "sha512-70W5TnRX5MroXVN0munWpF5q/AAWlamoy+PUL6cnDgc7cfnRiHHrndY++ZpWczNif8t4fQKVtC4jdUemnyb8Ag==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.39.tgz",
+      "integrity": "sha512-+t6QdzJCngH19hV7ClpFAeFDI2ko/HNcFbiNwaXTMVLB3hWi1sJtn+fzZck5HfzN4qsajAVqZq4nwX69SSt25A==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-sunos-64": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-sunos-64/-/esbuild-sunos-64-0.14.25.tgz",
-      "integrity": "sha512-UImichNlQInjErof7tuoG/8VVbrn8Y5EVVMI4M+RoCafWh9NSl4a57hohcgwbeGwl5NcGJtHg+l/WqzlHQFFsQ==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-sunos-64/-/esbuild-sunos-64-0.14.39.tgz",
+      "integrity": "sha512-HLfXG6i2p3wyyyWHeeP4ShGDJ1zRMnf9YLJLe2ezv2KqvcKw/Un/m/FBuDW1p13oSUO7ShISMzgc1dw1GGBEOQ==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-windows-32": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-windows-32/-/esbuild-windows-32-0.14.25.tgz",
-      "integrity": "sha512-OFisPQBbuIH8wMRm//fs7wQ7d6t1PuLylIUsUSgignjEV3BOts4+pjtq0J8Aq9kkKoVp8HGSJjaxpc6v2ER/KA==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-windows-32/-/esbuild-windows-32-0.14.39.tgz",
+      "integrity": "sha512-ZpSQcKbVSCU3ln7mHpsL/5dWsUqCNdTnC5YAArnaOwdrlIunrsbo5j4MOZRRcGExb2uvTc/rb+D3mlGb8j1rkA==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-windows-64": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-windows-64/-/esbuild-windows-64-0.14.25.tgz",
-      "integrity": "sha512-BgIxcEcqr4pfRc9fXStIXQVpjIkBUc3XHFEjH2t2R9pcEDU4BpMsdBgj0UA2x3Z0KtwVLLCOZDvSiaL+WkiTqA==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-windows-64/-/esbuild-windows-64-0.14.39.tgz",
+      "integrity": "sha512-I3gCdO8+6IDhT4Y1ZmV4o2Gg0oELv7N4kCcE4kqclz10fWHNjf19HQNHyBJe0AWnFV5ZfT154VVD31dqgwpgFw==",
       "dev": true,
       "optional": true
     },
     "@netlify/esbuild-windows-arm64": {
-      "version": "0.14.25",
-      "resolved": "https://registry.npmjs.org/@netlify/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.25.tgz",
-      "integrity": "sha512-B5Neu8aXqucUthCvAwVX7IvKbNSD/n3VFiQQcH0YQ+mtbzEIRIFaEAIanGdkmLx0shVBOlY9JxIeRThGPt2/2A==",
+      "version": "0.14.39",
+      "resolved": "https://registry.npmjs.org/@netlify/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.39.tgz",
+      "integrity": "sha512-WX52W8U1lsfWcz6NWoSpDs57lgiiMHN23seq8G2bvxzGS/tvYD3dxVLLW5UPoKSnFDyVQT7b6Zkt6AkBten1yQ==",
       "dev": true,
       "optional": true
     },
@@ -3058,20 +3079,20 @@
       }
     },
     "@netlify/functions-utils": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@netlify/functions-utils/-/functions-utils-4.2.7.tgz",
-      "integrity": "sha512-A5zwQFnuvvdHFzrKKT3SbYDACWucP5fXb2Qjo1U4dTWMjeOOyqNONxmtP91LbWTG3gYIVCafYZXq8VBIF5sPGQ==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@netlify/functions-utils/-/functions-utils-4.2.10.tgz",
+      "integrity": "sha512-OodKCe8fmD/uK3sGkfcBi6bwOuM/V1/gMf//67/4HkIUj1haaEICcJmpw17r7RwyseIwOEvdBV5oHEmSyOhDhA==",
       "dev": true,
       "requires": {
-        "@netlify/zip-it-and-ship-it": "^7.1.0",
+        "@netlify/zip-it-and-ship-it": "^7.1.2",
         "cpy": "^8.1.0",
         "path-exists": "^5.0.0"
       }
     },
     "@netlify/git-utils": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@netlify/git-utils/-/git-utils-4.1.1.tgz",
-      "integrity": "sha512-nErJowHlUHd36R/1KsXFEh9a5VL98/fr/IjwealZRQK+2E4Pm9t/KBkvR+LAyqWoINrrtkbpwjBRnO4r034OUg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@netlify/git-utils/-/git-utils-4.1.2.tgz",
+      "integrity": "sha512-Eee5Ht/bHPUV1cGaPF7kqV5V/78cXX0qyVDRDY72Crouw1F7V7D42yWpyf7/HrIg87LdzYoTmNwff7LMUTG4QA==",
       "dev": true,
       "requires": {
         "execa": "^6.0.0",
@@ -3166,15 +3187,15 @@
       "dev": true
     },
     "@netlify/plugins-list": {
-      "version": "6.41.0",
-      "resolved": "https://registry.npmjs.org/@netlify/plugins-list/-/plugins-list-6.41.0.tgz",
-      "integrity": "sha512-WUXn1kk1oDumzYKQVAf3Z5xQkVuHyR6k+LGt2qq6rFlxILmFA3gWMSf+AwVfT2bYK8gHWcdz2I9MSo5hbp1ohQ==",
+      "version": "6.46.0",
+      "resolved": "https://registry.npmjs.org/@netlify/plugins-list/-/plugins-list-6.46.0.tgz",
+      "integrity": "sha512-kUX90Eacqko9ni3cepVZKXFTLmhdwES/HDRlMYxyUh+SmvXWRC+h43b11nA0/6M5PEPolUChQOZN9wZql6oJJw==",
       "dev": true
     },
     "@netlify/run-utils": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@netlify/run-utils/-/run-utils-4.0.1.tgz",
-      "integrity": "sha512-6xwmYJWcQkRTdtA/u6WFRYBTuU7j9j+lh7Ld2+6TsUricnyg4orMIKQBdmVYM3tGbzzAidTOjzmbc8XXzQOo6g==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@netlify/run-utils/-/run-utils-4.0.2.tgz",
+      "integrity": "sha512-UH7AIkZ0TDOj6u2Kf+cTGNlM4twMV43AjJnVCdnUXBzZmFlV6p9ymwu7GYM33iXsid8i6cDBhRWQ03HcfPssIQ==",
       "dev": true,
       "requires": {
         "execa": "^6.0.0"
@@ -3242,14 +3263,14 @@
       }
     },
     "@netlify/zip-it-and-ship-it": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-7.1.0.tgz",
-      "integrity": "sha512-9kERr20cdfdiHyNGnUZih3vBEBnVTNlkxDWzD5y6XyXepGxifnxfThsAARLR8gr3DrwFzvsIgZaMbCtGE2JMow==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-7.1.2.tgz",
+      "integrity": "sha512-WGCt5KDk5Zr+A0fhPGEgAAW2aNiGyLcZohBq4nu/4BoFtHkk+8vCZOH1lMytZiIFu0eAq00j2q4kdzyLFV0Wuw==",
       "dev": true,
       "requires": {
         "@babel/parser": "7.16.8",
         "@netlify/binary-info": "^1.0.0",
-        "@netlify/esbuild": "0.14.25",
+        "@netlify/esbuild": "0.14.39",
         "@vercel/nft": "^0.22.0",
         "archiver": "^5.3.0",
         "common-path-prefix": "^3.0.0",
@@ -6249,13 +6270,13 @@
       }
     },
     "cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
       "requires": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
       },
       "dependencies": {
@@ -6429,9 +6450,9 @@
       "dev": true
     },
     "commander": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
-      "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
+      "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
       "dev": true
     },
     "common-path-prefix": {
@@ -7788,19 +7809,19 @@
       },
       "dependencies": {
         "@typescript-eslint/types": {
-          "version": "5.36.2",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.36.2.tgz",
-          "integrity": "sha512-9OJSvvwuF1L5eS2EQgFUbECb99F0mwq501w0H0EkYULkhFa19Qq7WFbycdw1PexAc929asupbZcgjVIe6OK/XQ==",
+          "version": "5.38.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.38.1.tgz",
+          "integrity": "sha512-QTW1iHq1Tffp9lNfbfPm4WJabbvpyaehQ0SrvVK2yfV79SytD9XDVxqiPvdrv2LK7DGSFo91TB2FgWanbJAZXg==",
           "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-          "version": "5.36.2",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.36.2.tgz",
-          "integrity": "sha512-8fyH+RfbKc0mTspfuEjlfqA4YywcwQK2Amcf6TDOwaRLg7Vwdu4bZzyvBZp4bjt1RRjQ5MDnOZahxMrt2l5v9w==",
+          "version": "5.38.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.38.1.tgz",
+          "integrity": "sha512-99b5e/Enoe8fKMLdSuwrfH/C0EIbpUWmeEKHmQlGZb8msY33qn1KlkFww0z26o5Omx7EVjzVDCWEfrfCDHfE7g==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.36.2",
-            "@typescript-eslint/visitor-keys": "5.36.2",
+            "@typescript-eslint/types": "5.38.1",
+            "@typescript-eslint/visitor-keys": "5.38.1",
             "debug": "^4.3.4",
             "globby": "^11.1.0",
             "is-glob": "^4.0.3",
@@ -7809,12 +7830,12 @@
           }
         },
         "@typescript-eslint/visitor-keys": {
-          "version": "5.36.2",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.36.2.tgz",
-          "integrity": "sha512-BtRvSR6dEdrNt7Net2/XDjbYKU5Ml6GqJgVfXT0CxTCJlnIqK7rAGreuWKMT2t8cFUT2Msv5oxw0GMRD7T5J7A==",
+          "version": "5.38.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.38.1.tgz",
+          "integrity": "sha512-bSHr1rRxXt54+j2n4k54p4fj8AHJ49VDWtjpImOpzQj4qjAiOpPni+V1Tyajh19Api1i844F757cur8wH3YvOA==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.36.2",
+            "@typescript-eslint/types": "5.38.1",
             "eslint-visitor-keys": "^3.3.0"
           }
         },
@@ -12292,9 +12313,9 @@
       }
     },
     "is-unicode-supported": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.2.0.tgz",
-      "integrity": "sha512-wH+U77omcRzevfIG8dDhTS0V9zZyweakfD01FULl97+0EHiJTTZtJqxPSkIIo/SDPv/i07k/C9jAPY+jwLLeUQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
       "dev": true
     },
     "is-upper-case": {
@@ -13042,9 +13063,9 @@
       }
     },
     "luxon": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.3.tgz",
-      "integrity": "sha512-+EfHWnF+UT7GgTnq5zXg3ldnTKL2zdv7QJgsU5bjjpbH17E3qi/puMhQyJVYuCq+FRkogvB5WB6iVvUr+E4a7w==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.4.tgz",
+      "integrity": "sha512-aV48rGUwP/Vydn8HT+5cdr26YYQiUZ42NM6ToMoaGKwYfWbfLeRkEu1wXWMHBZT6+KyLfcbbtVcoQFCbbPjKlw==",
       "dev": true
     },
     "macos-release": {
@@ -17291,9 +17312,9 @@
       "dev": true
     },
     "supports-color": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.2.2.tgz",
-      "integrity": "sha512-XC6g/Kgux+rJXmwokjm9ECpD6k/smUoS5LKlUCcsYr4IY3rW0XyAympon2RmxGrlnZURMpg5T18gWDP9CsHXFA==",
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.2.3.tgz",
+      "integrity": "sha512-aszYUX/DVK/ed5rFLb/dDinVJrQjG/vmU433wtqVSD800rYsJNWxh2R3USV90aLSU+UsyQkbNeffVLzc6B6foA==",
       "dev": true
     },
     "supports-preserve-symlinks-flag": {
@@ -18651,12 +18672,12 @@
       }
     },
     "yargs": {
-      "version": "17.5.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
-      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
+      "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
       "dev": true,
       "requires": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@gatsbyjs/reach-router": "^1.3.6",
-    "@netlify/build": "^27.17.1",
+    "@netlify/build": "^27.20.1",
     "@types/fs-extra": "^9.0.12",
     "@types/multer": "^1.4.7",
     "@types/semver": "^7.3.9",

--- a/plugin/test/unit/index.spec.ts
+++ b/plugin/test/unit/index.spec.ts
@@ -53,7 +53,7 @@ const constants = {
   INTERNAL_FUNCTIONS_SRC: 'demo/.netlify/internal-functions',
   PUBLISH_DIR: 'demo/public',
   FUNCTIONS_DIST: 'demo/.netlify/functions',
-  EDGE_HANDLERS_DIST: 'demo/.netlify/edge-functions-dist/',
+  EDGE_FUNCTIONS_DIST: 'demo/.netlify/edge-functions-dist/',
   IS_LOCAL: true,
   NETLIFY_BUILD_VERSION: '9000.0.0',
   SITE_ID: chance.guid(),
@@ -75,7 +75,7 @@ const netlifyConfig = {
   functions: { '*': {} },
   redirects: [],
   headers: [],
-  edge_handlers: [],
+  edge_functions: [],
   plugins: [],
 }
 


### PR DESCRIPTION
### Summary

Updating to @netlify/build@27.20.1 breaks the tests because Netlify Config and the constants now use 'edge functions' terminology as opposed to 'edge handlers'.

This PR fixes the tests.