### PR TITLE
fix: prevent reach-router dep requirement for v2

### DIFF
--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -16,7 +16,6 @@ import {
   shouldSkipBundlingDatastore,
 } from './helpers/config'
 import { modifyFiles } from './helpers/files'
-import { deleteFunctions } from './helpers/functions'
 import { checkZipSize } from './helpers/verification'
 
 const DEFAULT_FUNCTIONS_SRC = 'netlify/functions'
@@ -63,8 +62,6 @@ The plugin no longer uses this and it should be deleted to avoid conflicts.\n`)
 
   const neededFunctions = await getNeededFunctions(cacheDir)
 
-  await deleteFunctions(constants)
-
   if (shouldSkipBundlingDatastore()) {
     console.log('Creating site data metadata file')
     await createMetadataFileAndCopyDatastore(PUBLISH_DIR, cacheDir)
@@ -72,6 +69,7 @@ The plugin no longer uses this and it should be deleted to avoid conflicts.\n`)
   // Gatsby V2 does not have functions so we can skip this step
   if (neededFunctions.length !== 0) {
     const helperFunctions = await import('./helpers/functions')
+    await helperFunctions.deleteFunctions(constants)
     await helperFunctions.writeFunctions({
       constants,
       netlifyConfig,

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -16,7 +16,7 @@ import {
   shouldSkipBundlingDatastore,
 } from './helpers/config'
 import { modifyFiles } from './helpers/files'
-import { deleteFunctions, writeFunctions } from './helpers/functions'
+import { deleteFunctions } from './helpers/functions'
 import { checkZipSize } from './helpers/verification'
 
 const DEFAULT_FUNCTIONS_SRC = 'netlify/functions'

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -16,6 +16,7 @@ import {
   shouldSkipBundlingDatastore,
 } from './helpers/config'
 import { modifyFiles } from './helpers/files'
+import { deleteFunctions, writeFunctions } from './helpers/functions'
 import { checkZipSize } from './helpers/verification'
 
 const DEFAULT_FUNCTIONS_SRC = 'netlify/functions'
@@ -62,20 +63,15 @@ The plugin no longer uses this and it should be deleted to avoid conflicts.\n`)
 
   const neededFunctions = await getNeededFunctions(cacheDir)
 
+  await deleteFunctions(constants)
+
   if (shouldSkipBundlingDatastore()) {
     console.log('Creating site data metadata file')
     await createMetadataFileAndCopyDatastore(PUBLISH_DIR, cacheDir)
   }
-  // Gatsby V2 does not have functions so we can skip this step
-  if (neededFunctions.length !== 0) {
-    const helperFunctions = await import('./helpers/functions')
-    await helperFunctions.deleteFunctions(constants)
-    await helperFunctions.writeFunctions({
-      constants,
-      netlifyConfig,
-      neededFunctions,
-    })
-  }
+
+  await writeFunctions({ constants, netlifyConfig, neededFunctions })
+
   await modifyConfig({ netlifyConfig, cacheDir, neededFunctions })
 
   await modifyFiles({ netlifyConfig, neededFunctions })

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -69,9 +69,11 @@ The plugin no longer uses this and it should be deleted to avoid conflicts.\n`)
     console.log('Creating site data metadata file')
     await createMetadataFileAndCopyDatastore(PUBLISH_DIR, cacheDir)
   }
-
-  await writeFunctions({ constants, netlifyConfig, neededFunctions })
-
+// Gatsby V2 does not have functions so we can skip this step
+  if (neededFunctions.length !== 0) {
+    const helperFunctions = await import('./helpers/functions')
+    await helperFunctions.writeFunctions({ constants, netlifyConfig, neededFunctions })
+  }
   await modifyConfig({ netlifyConfig, cacheDir, neededFunctions })
 
   await modifyFiles({ netlifyConfig, neededFunctions })

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -69,10 +69,14 @@ The plugin no longer uses this and it should be deleted to avoid conflicts.\n`)
     console.log('Creating site data metadata file')
     await createMetadataFileAndCopyDatastore(PUBLISH_DIR, cacheDir)
   }
-// Gatsby V2 does not have functions so we can skip this step
+  // Gatsby V2 does not have functions so we can skip this step
   if (neededFunctions.length !== 0) {
     const helperFunctions = await import('./helpers/functions')
-    await helperFunctions.writeFunctions({ constants, netlifyConfig, neededFunctions })
+    await helperFunctions.writeFunctions({
+      constants,
+      netlifyConfig,
+      neededFunctions,
+    })
   }
   await modifyConfig({ netlifyConfig, cacheDir, neededFunctions })
 

--- a/plugin/src/templates/handlers.ts
+++ b/plugin/src/templates/handlers.ts
@@ -135,11 +135,11 @@ const getHandler = (renderMode: RenderMode, appDir: string): Handler => {
  * Generate an API handler
  */
 
-const apiHandler = javascript`(appDir: string): Handler =>
+const apiHandler = javascript`(appDir) =>
   function handler(
-    event: HandlerEvent,
-    context: HandlerContext,
-  ): Promise<HandlerResponse> {
+    event,
+    context,
+  ) {
     // Create a fake Gatsby/Express Request object
     const req = createRequestObject({ event, context })
 

--- a/plugin/src/templates/handlers.ts
+++ b/plugin/src/templates/handlers.ts
@@ -1,9 +1,4 @@
-import type {
-  Handler,
-  HandlerContext,
-  HandlerEvent,
-  HandlerResponse,
-} from '@netlify/functions'
+import type { Handler, HandlerEvent } from '@netlify/functions'
 import { stripIndent as javascript } from 'common-tags'
 import type { GatsbyFunctionRequest } from 'gatsby'
 import type {
@@ -19,8 +14,6 @@ const { join } = require('path')
 
 const etag = require('etag')
 
-const { gatsbyFunction } = require('./api/gatsbyFunction')
-const { createRequestObject, createResponseObject } = require('./api/utils')
 const {
   getPagePathFromPageDataPath,
   getGraphQLEngine,
@@ -142,7 +135,7 @@ const getHandler = (renderMode: RenderMode, appDir: string): Handler => {
  * Generate an API handler
  */
 
-const getApiHandler = (appDir: string): Handler =>
+const apiHandler = javascript`(appDir: string): Handler =>
   function handler(
     event: HandlerEvent,
     context: HandlerContext,
@@ -158,11 +151,11 @@ const getApiHandler = (appDir: string): Handler =>
         // Try to call the actual function
         gatsbyFunction(req, res, event, appDir)
       } catch (error) {
-        console.error(`Error executing ${event.path}`, error)
+        console.error(\`Error executing \${event.path}\`, error)
         resolve({ statusCode: 500 })
       }
     })
-  }
+  }`
 
 export const makeHandler = (appDir: string, renderMode: RenderMode): string =>
   // This is a string, but if you have the right editor plugin it should format as js
@@ -188,5 +181,5 @@ export const makeApiHandler = (appDir: string): string =>
     const { resolve } = require("path");
 
     const pageRoot = resolve(__dirname, "${appDir}");
-    exports.handler = ((${getApiHandler.toString()})(pageRoot))
+    exports.handler = ((${apiHandler})(pageRoot))
 `


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/frameworks as the Reviewer -->

### Summary
When using the current plugin version with Gatsby V2, users were running into this error:
![Screenshot 2023-02-07 at 2 24 07 PM](https://user-images.githubusercontent.com/43764894/217356923-4840bc52-349d-4a30-b8c5-625672578209.png)

With the previous Dynamic import update, there were issues that could have emerged when placing the `deleteFunctions` within the conditional. This new change converts the `getApiHandler` function (where reach-router is being called) into a string and prevents reach-router from being required as a dependency for v2 sites. 

`makeApiHandler` contains `getApiHandler` and is only called when creating a function. 

<!-- Provide a brief summary of the change. -->

### Test plan

1. Can test it with a V2 site and make sure the above error doesn't appear 
    - Example site: https://github.com/taty2010/gatsby-v2-test (will need to uninstall @gatsbyjs/reach-router)

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
Ref: https://github.com/netlify/netlify-plugin-gatsby/issues/556

![download](https://user-images.githubusercontent.com/43764894/217360527-4dccdef7-12d4-471d-beb0-0f9ea66eeb1b.jpg)

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was
published correctly.
