### PR TITLE
chore: add back ignore check to allow deploys when changing plugin without changing demo site

### DIFF
--- a/demo/netlify.toml
+++ b/demo/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 command = "npm run build"
 publish = "public/"
-# ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../plugin/"
+ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../plugin/"
 
 [[plugins]]
 package = "../plugin/src/index.ts"

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -16,7 +16,6 @@ import {
   shouldSkipBundlingDatastore,
 } from './helpers/config'
 import { modifyFiles } from './helpers/files'
-import { deleteFunctions } from './helpers/functions'
 import { checkZipSize } from './helpers/verification'
 
 const DEFAULT_FUNCTIONS_SRC = 'netlify/functions'
@@ -63,8 +62,6 @@ The plugin no longer uses this and it should be deleted to avoid conflicts.\n`)
 
   const neededFunctions = await getNeededFunctions(cacheDir)
 
-  await deleteFunctions(constants)
-
   if (shouldSkipBundlingDatastore()) {
     console.log('Creating site data metadata file')
     await createMetadataFileAndCopyDatastore(PUBLISH_DIR, cacheDir)
@@ -72,6 +69,7 @@ The plugin no longer uses this and it should be deleted to avoid conflicts.\n`)
   // Gatsby V2 does not have functions so we can skip this step
   if (neededFunctions.length !== 0) {
     const helperFunctions = await import('./helpers/functions')
+    await helperFunctions.deleteFunctions(constants)
     await helperFunctions.writeFunctions({
       constants,
       netlifyConfig,

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -16,7 +16,7 @@ import {
   shouldSkipBundlingDatastore,
 } from './helpers/config'
 import { modifyFiles } from './helpers/files'
-import { deleteFunctions, writeFunctions } from './helpers/functions'
+import { deleteFunctions } from './helpers/functions'
 import { checkZipSize } from './helpers/verification'
 
 const DEFAULT_FUNCTIONS_SRC = 'netlify/functions'

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -16,6 +16,7 @@ import {
   shouldSkipBundlingDatastore,
 } from './helpers/config'
 import { modifyFiles } from './helpers/files'
+import { deleteFunctions, writeFunctions } from './helpers/functions'
 import { checkZipSize } from './helpers/verification'
 
 const DEFAULT_FUNCTIONS_SRC = 'netlify/functions'
@@ -62,20 +63,15 @@ The plugin no longer uses this and it should be deleted to avoid conflicts.\n`)
 
   const neededFunctions = await getNeededFunctions(cacheDir)
 
+  await deleteFunctions(constants)
+
   if (shouldSkipBundlingDatastore()) {
     console.log('Creating site data metadata file')
     await createMetadataFileAndCopyDatastore(PUBLISH_DIR, cacheDir)
   }
-  // Gatsby V2 does not have functions so we can skip this step
-  if (neededFunctions.length !== 0) {
-    const helperFunctions = await import('./helpers/functions')
-    await helperFunctions.deleteFunctions(constants)
-    await helperFunctions.writeFunctions({
-      constants,
-      netlifyConfig,
-      neededFunctions,
-    })
-  }
+
+  await writeFunctions({ constants, netlifyConfig, neededFunctions })
+
   await modifyConfig({ netlifyConfig, cacheDir, neededFunctions })
 
   await modifyFiles({ netlifyConfig, neededFunctions })

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -69,9 +69,11 @@ The plugin no longer uses this and it should be deleted to avoid conflicts.\n`)
     console.log('Creating site data metadata file')
     await createMetadataFileAndCopyDatastore(PUBLISH_DIR, cacheDir)
   }
-
-  await writeFunctions({ constants, netlifyConfig, neededFunctions })
-
+// Gatsby V2 does not have functions so we can skip this step
+  if (neededFunctions.length !== 0) {
+    const helperFunctions = await import('./helpers/functions')
+    await helperFunctions.writeFunctions({ constants, netlifyConfig, neededFunctions })
+  }
   await modifyConfig({ netlifyConfig, cacheDir, neededFunctions })
 
   await modifyFiles({ netlifyConfig, neededFunctions })

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -69,10 +69,14 @@ The plugin no longer uses this and it should be deleted to avoid conflicts.\n`)
     console.log('Creating site data metadata file')
     await createMetadataFileAndCopyDatastore(PUBLISH_DIR, cacheDir)
   }
-// Gatsby V2 does not have functions so we can skip this step
+  // Gatsby V2 does not have functions so we can skip this step
   if (neededFunctions.length !== 0) {
     const helperFunctions = await import('./helpers/functions')
-    await helperFunctions.writeFunctions({ constants, netlifyConfig, neededFunctions })
+    await helperFunctions.writeFunctions({
+      constants,
+      netlifyConfig,
+      neededFunctions,
+    })
   }
   await modifyConfig({ netlifyConfig, cacheDir, neededFunctions })
 

--- a/plugin/src/templates/handlers.ts
+++ b/plugin/src/templates/handlers.ts
@@ -135,11 +135,11 @@ const getHandler = (renderMode: RenderMode, appDir: string): Handler => {
  * Generate an API handler
  */
 
-const apiHandler = javascript`(appDir: string): Handler =>
+const apiHandler = javascript`(appDir) =>
   function handler(
-    event: HandlerEvent,
-    context: HandlerContext,
-  ): Promise<HandlerResponse> {
+    event,
+    context,
+  ) {
     // Create a fake Gatsby/Express Request object
     const req = createRequestObject({ event, context })
 

--- a/plugin/src/templates/handlers.ts
+++ b/plugin/src/templates/handlers.ts
@@ -1,9 +1,4 @@
-import type {
-  Handler,
-  HandlerContext,
-  HandlerEvent,
-  HandlerResponse,
-} from '@netlify/functions'
+import type { Handler, HandlerEvent } from '@netlify/functions'
 import { stripIndent as javascript } from 'common-tags'
 import type { GatsbyFunctionRequest } from 'gatsby'
 import type {
@@ -19,8 +14,6 @@ const { join } = require('path')
 
 const etag = require('etag')
 
-const { gatsbyFunction } = require('./api/gatsbyFunction')
-const { createRequestObject, createResponseObject } = require('./api/utils')
 const {
   getPagePathFromPageDataPath,
   getGraphQLEngine,
@@ -142,7 +135,7 @@ const getHandler = (renderMode: RenderMode, appDir: string): Handler => {
  * Generate an API handler
  */
 
-const getApiHandler = (appDir: string): Handler =>
+const apiHandler = javascript`(appDir: string): Handler =>
   function handler(
     event: HandlerEvent,
     context: HandlerContext,
@@ -158,11 +151,11 @@ const getApiHandler = (appDir: string): Handler =>
         // Try to call the actual function
         gatsbyFunction(req, res, event, appDir)
       } catch (error) {
-        console.error(`Error executing ${event.path}`, error)
+        console.error(\`Error executing \${event.path}\`, error)
         resolve({ statusCode: 500 })
       }
     })
-  }
+  }`
 
 export const makeHandler = (appDir: string, renderMode: RenderMode): string =>
   // This is a string, but if you have the right editor plugin it should format as js
@@ -188,5 +181,5 @@ export const makeApiHandler = (appDir: string): string =>
     const { resolve } = require("path");
 
     const pageRoot = resolve(__dirname, "${appDir}");
-    exports.handler = ((${getApiHandler.toString()})(pageRoot))
+    exports.handler = ((${apiHandler})(pageRoot))
 `


### PR DESCRIPTION
### Summary

PRs that don't touch `demo` site don't produce actual preview deploys for testing due to:

```
11:13:36 AM: No changes detected in base directory. Returning early from build.
11:13:36 AM: Failed during stage 'checking build content for changes': Canceled build due to no content change
```

The `ignore` setting was commented out in https://github.com/netlify/netlify-plugin-gatsby/pull/547 and this PR checks wether it's safe to bring it back. Alternatively maybe https://answers.netlify.com/t/builds-cancelled-for-a-new-branch-due-to-no-content-change/17169/2 could be used to force the deploy everytime.

This PR also includes changes from https://github.com/netlify/netlify-plugin-gatsby/pull/557 to be able to test them with actual Preview Deploy

### Test plan

1. Visit the Deploy Preview ([insert link to specific page]()) ...

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was
published correctly.
