### PR TITLE
chore(deps): update @netlify/ipx to ^1.4.0

### DIFF
--- a/demo-v5/package-lock.json
+++ b/demo-v5/package-lock.json
@@ -3054,9 +3054,9 @@
       ]
     },
     "node_modules/@netlify/functions": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@netlify/functions/-/functions-1.3.0.tgz",
-      "integrity": "sha512-hN/Fgpz8XIOBfsBPLYUMxVKBlCopgeqGB0popayicnmkFLnvKByTTMYgF01wcF9DBtBQdV0H2h1kPFpMl34I8w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@netlify/functions/-/functions-1.4.0.tgz",
+      "integrity": "sha512-gy7ULTIRroc2/jyFVGx1djCmmBMVisIwrvkqggq5B6iDcInRSy2Tpkm+V5C63hKJVkNRskKWtLQKm9ecCaQTjA==",
       "dev": true,
       "dependencies": {
         "is-promise": "^4.0.0"
@@ -3066,22 +3066,42 @@
       }
     },
     "node_modules/@netlify/ipx": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@netlify/ipx/-/ipx-1.3.1.tgz",
-      "integrity": "sha512-kjw26KYM1jLe+bGRnhqxWs0ACG8eg6kN6wV7uqUu1J8dE6QC73ksyVtCA6IAHl3/5qf5RyMUzquNCp0N0+lXEw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@netlify/ipx/-/ipx-1.4.0.tgz",
+      "integrity": "sha512-Ibqg1W41EVMHNT/W6JSDUyxjhcxsbEL9vL9ZaNjn9tVKnDYxJ8JqRTwSbzfns+K+M3FLqoC4PLW32qW+vT1pKQ==",
       "dev": true,
       "dependencies": {
-        "@netlify/functions": "^1.3.0",
+        "@netlify/functions": "^1.4.0",
         "etag": "^1.8.1",
-        "fs-extra": "^10.0.0",
+        "fs-extra": "^11.0.0",
         "ipx": "^0.9.11",
         "micromatch": "^4.0.5",
         "mkdirp": "^1.0.4",
         "murmurhash": "^2.0.0",
         "node-fetch": "^2.0.0",
-        "ufo": "^0.8.0",
-        "unstorage": "^0.6.0"
+        "ufo": "^1.0.0",
+        "unstorage": "^1.0.0"
       }
+    },
+    "node_modules/@netlify/ipx/node_modules/fs-extra": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@netlify/ipx/node_modules/ufo": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.1.tgz",
+      "integrity": "sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==",
+      "dev": true
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
@@ -7350,9 +7370,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.1.tgz",
-      "integrity": "sha512-aA964RUCsBt0FGoNIlA3uFgo2hO+WWC0fiC6DBps/0SFzkKcYoM/3CzVLIa5xSsrFjdioMdYgAIbwo80qp2MoA==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
+      "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==",
       "dev": true
     },
     "node_modules/del": {
@@ -7426,9 +7446,9 @@
       }
     },
     "node_modules/destr": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/destr/-/destr-1.2.1.tgz",
-      "integrity": "sha512-ud8w0qMLlci6iFG7CNgeRr8OcbUWMsbfjtWft1eJ5Luqrz/M8Ebqk/KCzne8rKUlIQWWfLv0wD6QHrqOf4GshA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-1.2.2.tgz",
+      "integrity": "sha512-lrbCJwD9saUQrqUfXvl6qoM+QN3W7tLV5pAOs+OqOmopCCz/JkE05MHedJR1xfk4IAnZuJXPVuN5+7jNA2ZCiA==",
       "dev": true
     },
     "node_modules/destroy": {
@@ -11771,16 +11791,25 @@
       }
     },
     "node_modules/h3": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-0.8.6.tgz",
-      "integrity": "sha512-CSWNOKa3QGo67rFU2PhbFTp0uPJtilNji2Z0pMiSRQt3+OkIW0u3E1WMJqIycLqaTgb9JyFqH/S4mcTyyGtvyQ==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.6.4.tgz",
+      "integrity": "sha512-uoDNeaoeDRwWBtwwi4siZ6l5sBmDJpnpcBssuAbvsaPBonl8vP7Ym4tFPe+tAvGM0GbUoC24wYcloCG+J9hqmA==",
       "dev": true,
       "dependencies": {
         "cookie-es": "^0.5.0",
-        "destr": "^1.2.0",
-        "radix3": "^0.2.1",
-        "ufo": "^0.8.6"
+        "defu": "^6.1.2",
+        "destr": "^1.2.2",
+        "iron-webcrypto": "^0.6.0",
+        "radix3": "^1.0.1",
+        "ufo": "^1.1.1",
+        "uncrypto": "^0.1.2"
       }
+    },
+    "node_modules/h3/node_modules/ufo": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.1.tgz",
+      "integrity": "sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==",
+      "dev": true
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -12432,15 +12461,15 @@
       }
     },
     "node_modules/ioredis": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.2.4.tgz",
-      "integrity": "sha512-qIpuAEt32lZJQ0XyrloCRdlEdUUNGG9i0UOk6zgzK6igyudNWqEBxfH6OlbnOOoBBvr1WB02mm8fR55CnikRng==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.1.tgz",
+      "integrity": "sha512-C+IBcMysM6v52pTLItYMeV4Hz7uriGtoJdz7SSBDX6u+zwSYGirLdQh3L7t/OItWITcw3gTFMjJReYUwS4zihg==",
       "dev": true,
       "dependencies": {
         "@ioredis/commands": "^1.1.1",
         "cluster-key-slot": "^1.1.0",
         "debug": "^4.3.4",
-        "denque": "^2.0.1",
+        "denque": "^2.1.0",
         "lodash.defaults": "^4.2.0",
         "lodash.isarguments": "^3.1.0",
         "redis-errors": "^1.2.0",
@@ -12518,6 +12547,15 @@
       },
       "bin": {
         "ipx": "bin/ipx.mjs"
+      }
+    },
+    "node_modules/iron-webcrypto": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-0.6.0.tgz",
+      "integrity": "sha512-WYgEQttulX/+JTv1BTJFYY3OsAb+ZnCuA53IjppZMyiRsVdGeEuZ/k4fJrg77Rzn0pp9/PgWtXUF+5HndDA5SQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/brc-dd"
       }
     },
     "node_modules/is-absolute": {
@@ -15052,15 +15090,6 @@
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
       "integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw=="
     },
-    "node_modules/mkdir": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/mkdir/-/mkdir-0.0.2.tgz",
-      "integrity": "sha512-98OnjcWaNEIRUJJe9rFoWlbkQ5n9z8F86wIPCrI961YEViiVybTuJln919WuuSHSnlrqXy0ELKCntoPy8C7lqg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -15743,6 +15772,29 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/objectFitPolyfill/-/objectFitPolyfill-2.3.5.tgz",
       "integrity": "sha512-8Quz071ZmGi0QWEG4xB3Bv5Lpw6K0Uca87FLoLMKMWjB6qIq9IyBegP3b/VLNxv2WYvIMGoeUQ+c6ibUkNa8TA=="
+    },
+    "node_modules/ofetch": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.0.1.tgz",
+      "integrity": "sha512-icBz2JYfEpt+wZz1FRoGcrMigjNKjzvufE26m9+yUiacRQRHwnNlGRPiDnW4op7WX/MR6aniwS8xw8jyVelF2g==",
+      "dev": true,
+      "dependencies": {
+        "destr": "^1.2.2",
+        "node-fetch-native": "^1.0.2",
+        "ufo": "^1.1.0"
+      }
+    },
+    "node_modules/ofetch/node_modules/node-fetch-native": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.1.0.tgz",
+      "integrity": "sha512-nl5goFCig93JZ9FIV8GHT9xpNqXbxQUzkOmKIMKmncsBH9jhg7qKex8hirpymkBFmNQ114chEEG5lS4wgK2I+Q==",
+      "dev": true
+    },
+    "node_modules/ofetch/node_modules/ufo": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.1.tgz",
+      "integrity": "sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==",
+      "dev": true
     },
     "node_modules/ohmyfetch": {
       "version": "0.4.21",
@@ -17511,9 +17563,9 @@
       }
     },
     "node_modules/radix3": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/radix3/-/radix3-0.2.1.tgz",
-      "integrity": "sha512-FnhArTl5Tq7dodiLeSPKrDUyCQuJqEncP8cKdyy399g8F/cz7GH6FmzA3Rkosu2IZMkpswFFwXfb2ERSiL06pg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.0.1.tgz",
+      "integrity": "sha512-y+AcwZ3HcUIGc9zGsNVf5+BY/LxL+z+4h4J3/pp8jxSmy1STaCocPS3qrj4tA5ehUSzqtqK+0Aygvz/r/8vy4g==",
       "dev": true
     },
     "node_modules/randombytes": {
@@ -20173,6 +20225,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/uncrypto": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.2.tgz",
+      "integrity": "sha512-kuZwRKV615lEw/Xx3Iz56FKk3nOeOVGaVmw0eg+x4Mne28lCotNFbBhDW7dEBCBKyKbRQiCadEZeNAFPVC5cgw==",
+      "dev": true
+    },
     "node_modules/underscore.string": {
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.6.tgz",
@@ -20471,22 +20529,54 @@
       }
     },
     "node_modules/unstorage": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-0.6.0.tgz",
-      "integrity": "sha512-X05PIq28pVNA1BypX6Y00YNqAsHM25MGemvpjHeYvwJ8/wg936GoO1YD+VdWlqm3LmVX4fNJ5tlC7uhXsMPgeg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.4.1.tgz",
+      "integrity": "sha512-ETLczXBd7sjJZuA3oIzaYwhMShiGlo7cGx01Ww23x2ehlk6WiRR1YsmjDBipoiGorq8pX1RRoMQFp/n3me7QOg==",
       "dev": true,
       "dependencies": {
-        "anymatch": "^3.1.2",
+        "anymatch": "^3.1.3",
         "chokidar": "^3.5.3",
-        "destr": "^1.1.1",
-        "h3": "^0.8.1",
-        "ioredis": "^5.2.3",
-        "listhen": "^0.3.4",
-        "mkdir": "^0.0.2",
+        "destr": "^1.2.2",
+        "h3": "^1.5.0",
+        "ioredis": "^5.3.1",
+        "listhen": "^1.0.3",
+        "lru-cache": "^7.18.3",
         "mri": "^1.2.0",
-        "ohmyfetch": "^0.4.19",
-        "ufo": "^0.8.6",
-        "ws": "^8.9.0"
+        "node-fetch-native": "^1.0.2",
+        "ofetch": "^1.0.1",
+        "ufo": "^1.1.1"
+      },
+      "peerDependencies": {
+        "@azure/app-configuration": "^1.3.1",
+        "@azure/cosmos": "^3.17.3",
+        "@azure/data-tables": "^13.2.1",
+        "@azure/identity": "^3.1.3",
+        "@azure/keyvault-secrets": "^4.6.0",
+        "@azure/storage-blob": "^12.13.0",
+        "@planetscale/database": "^1.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@azure/app-configuration": {
+          "optional": true
+        },
+        "@azure/cosmos": {
+          "optional": true
+        },
+        "@azure/data-tables": {
+          "optional": true
+        },
+        "@azure/identity": {
+          "optional": true
+        },
+        "@azure/keyvault-secrets": {
+          "optional": true
+        },
+        "@azure/storage-blob": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        }
       }
     },
     "node_modules/unstorage/node_modules/clipboardy": {
@@ -20506,42 +20596,48 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/unstorage/node_modules/get-port-please": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.0.1.tgz",
+      "integrity": "sha512-R5pcVO8Z1+pVDu8Ml3xaJCEkBiiy1VQN9za0YqH8GIi1nIqD4IzQhzY6dDzMRtdS1lyiGlucRzm8IN8wtLIXng==",
+      "dev": true
+    },
     "node_modules/unstorage/node_modules/listhen": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/listhen/-/listhen-0.3.5.tgz",
-      "integrity": "sha512-suyt79hNmCFeBIyftcLqLPfYiXeB795gSUWOJT7nspl2IvREY0Q9xvchLhekxvQ0KiOPvWoyALnc9Mxoelm0Pw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/listhen/-/listhen-1.0.4.tgz",
+      "integrity": "sha512-r94k7kmXHb8e8wpv7+UP/qqhhD+j/9TgX19QKim2cEJuWCLwlTw+5BkCFmYyjhQ7Bt8KdVun/2DcD7MF2Fe3+g==",
       "dev": true,
       "dependencies": {
         "clipboardy": "^3.0.0",
         "colorette": "^2.0.19",
-        "defu": "^6.1.0",
-        "get-port-please": "^2.6.1",
+        "defu": "^6.1.2",
+        "get-port-please": "^3.0.1",
         "http-shutdown": "^1.2.2",
         "ip-regex": "^5.0.0",
         "node-forge": "^1.3.1",
-        "ufo": "^0.8.6"
+        "ufo": "^1.1.1"
       }
     },
-    "node_modules/unstorage/node_modules/ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+    "node_modules/unstorage/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "dev": true,
       "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
+        "node": ">=12"
       }
+    },
+    "node_modules/unstorage/node_modules/node-fetch-native": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.1.0.tgz",
+      "integrity": "sha512-nl5goFCig93JZ9FIV8GHT9xpNqXbxQUzkOmKIMKmncsBH9jhg7qKex8hirpymkBFmNQ114chEEG5lS4wgK2I+Q==",
+      "dev": true
+    },
+    "node_modules/unstorage/node_modules/ufo": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.1.tgz",
+      "integrity": "sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==",
+      "dev": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.10",

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -3018,9 +3018,9 @@
       ]
     },
     "node_modules/@netlify/functions": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@netlify/functions/-/functions-1.3.0.tgz",
-      "integrity": "sha512-hN/Fgpz8XIOBfsBPLYUMxVKBlCopgeqGB0popayicnmkFLnvKByTTMYgF01wcF9DBtBQdV0H2h1kPFpMl34I8w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@netlify/functions/-/functions-1.4.0.tgz",
+      "integrity": "sha512-gy7ULTIRroc2/jyFVGx1djCmmBMVisIwrvkqggq5B6iDcInRSy2Tpkm+V5C63hKJVkNRskKWtLQKm9ecCaQTjA==",
       "dev": true,
       "dependencies": {
         "is-promise": "^4.0.0"
@@ -3036,21 +3036,35 @@
       "dev": true
     },
     "node_modules/@netlify/ipx": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@netlify/ipx/-/ipx-1.3.1.tgz",
-      "integrity": "sha512-kjw26KYM1jLe+bGRnhqxWs0ACG8eg6kN6wV7uqUu1J8dE6QC73ksyVtCA6IAHl3/5qf5RyMUzquNCp0N0+lXEw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@netlify/ipx/-/ipx-1.4.0.tgz",
+      "integrity": "sha512-Ibqg1W41EVMHNT/W6JSDUyxjhcxsbEL9vL9ZaNjn9tVKnDYxJ8JqRTwSbzfns+K+M3FLqoC4PLW32qW+vT1pKQ==",
       "dev": true,
       "dependencies": {
-        "@netlify/functions": "^1.3.0",
+        "@netlify/functions": "^1.4.0",
         "etag": "^1.8.1",
-        "fs-extra": "^10.0.0",
+        "fs-extra": "^11.0.0",
         "ipx": "^0.9.11",
         "micromatch": "^4.0.5",
         "mkdirp": "^1.0.4",
         "murmurhash": "^2.0.0",
         "node-fetch": "^2.0.0",
-        "ufo": "^0.8.0",
-        "unstorage": "^0.6.0"
+        "ufo": "^1.0.0",
+        "unstorage": "^1.0.0"
+      }
+    },
+    "node_modules/@netlify/ipx/node_modules/fs-extra": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/@netlify/ipx/node_modules/mkdirp": {
@@ -3064,6 +3078,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@netlify/ipx/node_modules/ufo": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.1.tgz",
+      "integrity": "sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==",
+      "dev": true
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
@@ -7390,9 +7410,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.1.tgz",
-      "integrity": "sha512-aA964RUCsBt0FGoNIlA3uFgo2hO+WWC0fiC6DBps/0SFzkKcYoM/3CzVLIa5xSsrFjdioMdYgAIbwo80qp2MoA==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
+      "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==",
       "dev": true
     },
     "node_modules/del": {
@@ -7451,9 +7471,9 @@
       }
     },
     "node_modules/destr": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/destr/-/destr-1.2.1.tgz",
-      "integrity": "sha512-ud8w0qMLlci6iFG7CNgeRr8OcbUWMsbfjtWft1eJ5Luqrz/M8Ebqk/KCzne8rKUlIQWWfLv0wD6QHrqOf4GshA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-1.2.2.tgz",
+      "integrity": "sha512-lrbCJwD9saUQrqUfXvl6qoM+QN3W7tLV5pAOs+OqOmopCCz/JkE05MHedJR1xfk4IAnZuJXPVuN5+7jNA2ZCiA==",
       "dev": true
     },
     "node_modules/destroy": {
@@ -11064,16 +11084,25 @@
       }
     },
     "node_modules/h3": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-0.8.6.tgz",
-      "integrity": "sha512-CSWNOKa3QGo67rFU2PhbFTp0uPJtilNji2Z0pMiSRQt3+OkIW0u3E1WMJqIycLqaTgb9JyFqH/S4mcTyyGtvyQ==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.6.4.tgz",
+      "integrity": "sha512-uoDNeaoeDRwWBtwwi4siZ6l5sBmDJpnpcBssuAbvsaPBonl8vP7Ym4tFPe+tAvGM0GbUoC24wYcloCG+J9hqmA==",
       "dev": true,
       "dependencies": {
         "cookie-es": "^0.5.0",
-        "destr": "^1.2.0",
-        "radix3": "^0.2.1",
-        "ufo": "^0.8.6"
+        "defu": "^6.1.2",
+        "destr": "^1.2.2",
+        "iron-webcrypto": "^0.6.0",
+        "radix3": "^1.0.1",
+        "ufo": "^1.1.1",
+        "uncrypto": "^0.1.2"
       }
+    },
+    "node_modules/h3/node_modules/ufo": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.1.tgz",
+      "integrity": "sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==",
+      "dev": true
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -11720,15 +11749,15 @@
       }
     },
     "node_modules/ioredis": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.2.4.tgz",
-      "integrity": "sha512-qIpuAEt32lZJQ0XyrloCRdlEdUUNGG9i0UOk6zgzK6igyudNWqEBxfH6OlbnOOoBBvr1WB02mm8fR55CnikRng==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.1.tgz",
+      "integrity": "sha512-C+IBcMysM6v52pTLItYMeV4Hz7uriGtoJdz7SSBDX6u+zwSYGirLdQh3L7t/OItWITcw3gTFMjJReYUwS4zihg==",
       "dev": true,
       "dependencies": {
         "@ioredis/commands": "^1.1.1",
         "cluster-key-slot": "^1.1.0",
         "debug": "^4.3.4",
-        "denque": "^2.0.1",
+        "denque": "^2.1.0",
         "lodash.defaults": "^4.2.0",
         "lodash.isarguments": "^3.1.0",
         "redis-errors": "^1.2.0",
@@ -11800,6 +11829,15 @@
       },
       "bin": {
         "ipx": "bin/ipx.mjs"
+      }
+    },
+    "node_modules/iron-webcrypto": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-0.6.0.tgz",
+      "integrity": "sha512-WYgEQttulX/+JTv1BTJFYY3OsAb+ZnCuA53IjppZMyiRsVdGeEuZ/k4fJrg77Rzn0pp9/PgWtXUF+5HndDA5SQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/brc-dd"
       }
     },
     "node_modules/is-absolute": {
@@ -14610,15 +14648,6 @@
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
       "integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw=="
     },
-    "node_modules/mkdir": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/mkdir/-/mkdir-0.0.2.tgz",
-      "integrity": "sha512-98OnjcWaNEIRUJJe9rFoWlbkQ5n9z8F86wIPCrI961YEViiVybTuJln919WuuSHSnlrqXy0ELKCntoPy8C7lqg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -15192,6 +15221,29 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/objectFitPolyfill/-/objectFitPolyfill-2.3.5.tgz",
       "integrity": "sha512-8Quz071ZmGi0QWEG4xB3Bv5Lpw6K0Uca87FLoLMKMWjB6qIq9IyBegP3b/VLNxv2WYvIMGoeUQ+c6ibUkNa8TA=="
+    },
+    "node_modules/ofetch": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.0.1.tgz",
+      "integrity": "sha512-icBz2JYfEpt+wZz1FRoGcrMigjNKjzvufE26m9+yUiacRQRHwnNlGRPiDnW4op7WX/MR6aniwS8xw8jyVelF2g==",
+      "dev": true,
+      "dependencies": {
+        "destr": "^1.2.2",
+        "node-fetch-native": "^1.0.2",
+        "ufo": "^1.1.0"
+      }
+    },
+    "node_modules/ofetch/node_modules/node-fetch-native": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.1.0.tgz",
+      "integrity": "sha512-nl5goFCig93JZ9FIV8GHT9xpNqXbxQUzkOmKIMKmncsBH9jhg7qKex8hirpymkBFmNQ114chEEG5lS4wgK2I+Q==",
+      "dev": true
+    },
+    "node_modules/ofetch/node_modules/ufo": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.1.tgz",
+      "integrity": "sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==",
+      "dev": true
     },
     "node_modules/ohmyfetch": {
       "version": "0.4.21",
@@ -16784,9 +16836,9 @@
       }
     },
     "node_modules/radix3": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/radix3/-/radix3-0.2.1.tgz",
-      "integrity": "sha512-FnhArTl5Tq7dodiLeSPKrDUyCQuJqEncP8cKdyy399g8F/cz7GH6FmzA3Rkosu2IZMkpswFFwXfb2ERSiL06pg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.0.1.tgz",
+      "integrity": "sha512-y+AcwZ3HcUIGc9zGsNVf5+BY/LxL+z+4h4J3/pp8jxSmy1STaCocPS3qrj4tA5ehUSzqtqK+0Aygvz/r/8vy4g==",
       "dev": true
     },
     "node_modules/randombytes": {
@@ -19542,6 +19594,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/uncrypto": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.2.tgz",
+      "integrity": "sha512-kuZwRKV615lEw/Xx3Iz56FKk3nOeOVGaVmw0eg+x4Mne28lCotNFbBhDW7dEBCBKyKbRQiCadEZeNAFPVC5cgw==",
+      "dev": true
+    },
     "node_modules/underscore.string": {
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.6.tgz",
@@ -19811,22 +19869,54 @@
       }
     },
     "node_modules/unstorage": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-0.6.0.tgz",
-      "integrity": "sha512-X05PIq28pVNA1BypX6Y00YNqAsHM25MGemvpjHeYvwJ8/wg936GoO1YD+VdWlqm3LmVX4fNJ5tlC7uhXsMPgeg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.4.1.tgz",
+      "integrity": "sha512-ETLczXBd7sjJZuA3oIzaYwhMShiGlo7cGx01Ww23x2ehlk6WiRR1YsmjDBipoiGorq8pX1RRoMQFp/n3me7QOg==",
       "dev": true,
       "dependencies": {
-        "anymatch": "^3.1.2",
+        "anymatch": "^3.1.3",
         "chokidar": "^3.5.3",
-        "destr": "^1.1.1",
-        "h3": "^0.8.1",
-        "ioredis": "^5.2.3",
-        "listhen": "^0.3.4",
-        "mkdir": "^0.0.2",
+        "destr": "^1.2.2",
+        "h3": "^1.5.0",
+        "ioredis": "^5.3.1",
+        "listhen": "^1.0.3",
+        "lru-cache": "^7.18.3",
         "mri": "^1.2.0",
-        "ohmyfetch": "^0.4.19",
-        "ufo": "^0.8.6",
-        "ws": "^8.9.0"
+        "node-fetch-native": "^1.0.2",
+        "ofetch": "^1.0.1",
+        "ufo": "^1.1.1"
+      },
+      "peerDependencies": {
+        "@azure/app-configuration": "^1.3.1",
+        "@azure/cosmos": "^3.17.3",
+        "@azure/data-tables": "^13.2.1",
+        "@azure/identity": "^3.1.3",
+        "@azure/keyvault-secrets": "^4.6.0",
+        "@azure/storage-blob": "^12.13.0",
+        "@planetscale/database": "^1.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@azure/app-configuration": {
+          "optional": true
+        },
+        "@azure/cosmos": {
+          "optional": true
+        },
+        "@azure/data-tables": {
+          "optional": true
+        },
+        "@azure/identity": {
+          "optional": true
+        },
+        "@azure/keyvault-secrets": {
+          "optional": true
+        },
+        "@azure/storage-blob": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        }
       }
     },
     "node_modules/unstorage/node_modules/clipboardy": {
@@ -19852,42 +19942,48 @@
       "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
       "dev": true
     },
+    "node_modules/unstorage/node_modules/get-port-please": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.0.1.tgz",
+      "integrity": "sha512-R5pcVO8Z1+pVDu8Ml3xaJCEkBiiy1VQN9za0YqH8GIi1nIqD4IzQhzY6dDzMRtdS1lyiGlucRzm8IN8wtLIXng==",
+      "dev": true
+    },
     "node_modules/unstorage/node_modules/listhen": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/listhen/-/listhen-0.3.5.tgz",
-      "integrity": "sha512-suyt79hNmCFeBIyftcLqLPfYiXeB795gSUWOJT7nspl2IvREY0Q9xvchLhekxvQ0KiOPvWoyALnc9Mxoelm0Pw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/listhen/-/listhen-1.0.4.tgz",
+      "integrity": "sha512-r94k7kmXHb8e8wpv7+UP/qqhhD+j/9TgX19QKim2cEJuWCLwlTw+5BkCFmYyjhQ7Bt8KdVun/2DcD7MF2Fe3+g==",
       "dev": true,
       "dependencies": {
         "clipboardy": "^3.0.0",
         "colorette": "^2.0.19",
-        "defu": "^6.1.0",
-        "get-port-please": "^2.6.1",
+        "defu": "^6.1.2",
+        "get-port-please": "^3.0.1",
         "http-shutdown": "^1.2.2",
         "ip-regex": "^5.0.0",
         "node-forge": "^1.3.1",
-        "ufo": "^0.8.6"
+        "ufo": "^1.1.1"
       }
     },
-    "node_modules/unstorage/node_modules/ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+    "node_modules/unstorage/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "dev": true,
       "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
+        "node": ">=12"
       }
+    },
+    "node_modules/unstorage/node_modules/node-fetch-native": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.1.0.tgz",
+      "integrity": "sha512-nl5goFCig93JZ9FIV8GHT9xpNqXbxQUzkOmKIMKmncsBH9jhg7qKex8hirpymkBFmNQ114chEEG5lS4wgK2I+Q==",
+      "dev": true
+    },
+    "node_modules/unstorage/node_modules/ufo": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.1.tgz",
+      "integrity": "sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==",
+      "dev": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.10",
@@ -22831,9 +22927,9 @@
       "optional": true
     },
     "@netlify/functions": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@netlify/functions/-/functions-1.3.0.tgz",
-      "integrity": "sha512-hN/Fgpz8XIOBfsBPLYUMxVKBlCopgeqGB0popayicnmkFLnvKByTTMYgF01wcF9DBtBQdV0H2h1kPFpMl34I8w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@netlify/functions/-/functions-1.4.0.tgz",
+      "integrity": "sha512-gy7ULTIRroc2/jyFVGx1djCmmBMVisIwrvkqggq5B6iDcInRSy2Tpkm+V5C63hKJVkNRskKWtLQKm9ecCaQTjA==",
       "dev": true,
       "requires": {
         "is-promise": "^4.0.0"
@@ -22848,27 +22944,44 @@
       }
     },
     "@netlify/ipx": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@netlify/ipx/-/ipx-1.3.1.tgz",
-      "integrity": "sha512-kjw26KYM1jLe+bGRnhqxWs0ACG8eg6kN6wV7uqUu1J8dE6QC73ksyVtCA6IAHl3/5qf5RyMUzquNCp0N0+lXEw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@netlify/ipx/-/ipx-1.4.0.tgz",
+      "integrity": "sha512-Ibqg1W41EVMHNT/W6JSDUyxjhcxsbEL9vL9ZaNjn9tVKnDYxJ8JqRTwSbzfns+K+M3FLqoC4PLW32qW+vT1pKQ==",
       "dev": true,
       "requires": {
-        "@netlify/functions": "^1.3.0",
+        "@netlify/functions": "^1.4.0",
         "etag": "^1.8.1",
-        "fs-extra": "^10.0.0",
+        "fs-extra": "^11.0.0",
         "ipx": "^0.9.11",
         "micromatch": "^4.0.5",
         "mkdirp": "^1.0.4",
         "murmurhash": "^2.0.0",
         "node-fetch": "^2.0.0",
-        "ufo": "^0.8.0",
-        "unstorage": "^0.6.0"
+        "ufo": "^1.0.0",
+        "unstorage": "^1.0.0"
       },
       "dependencies": {
+        "fs-extra": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+          "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
         "mkdirp": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "ufo": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.1.tgz",
+          "integrity": "sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==",
           "dev": true
         }
       }
@@ -26112,9 +26225,9 @@
       }
     },
     "defu": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.1.tgz",
-      "integrity": "sha512-aA964RUCsBt0FGoNIlA3uFgo2hO+WWC0fiC6DBps/0SFzkKcYoM/3CzVLIa5xSsrFjdioMdYgAIbwo80qp2MoA==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
+      "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==",
       "dev": true
     },
     "del": {
@@ -26155,9 +26268,9 @@
       "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg=="
     },
     "destr": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/destr/-/destr-1.2.1.tgz",
-      "integrity": "sha512-ud8w0qMLlci6iFG7CNgeRr8OcbUWMsbfjtWft1eJ5Luqrz/M8Ebqk/KCzne8rKUlIQWWfLv0wD6QHrqOf4GshA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-1.2.2.tgz",
+      "integrity": "sha512-lrbCJwD9saUQrqUfXvl6qoM+QN3W7tLV5pAOs+OqOmopCCz/JkE05MHedJR1xfk4IAnZuJXPVuN5+7jNA2ZCiA==",
       "dev": true
     },
     "destroy": {
@@ -28916,15 +29029,26 @@
       }
     },
     "h3": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-0.8.6.tgz",
-      "integrity": "sha512-CSWNOKa3QGo67rFU2PhbFTp0uPJtilNji2Z0pMiSRQt3+OkIW0u3E1WMJqIycLqaTgb9JyFqH/S4mcTyyGtvyQ==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.6.4.tgz",
+      "integrity": "sha512-uoDNeaoeDRwWBtwwi4siZ6l5sBmDJpnpcBssuAbvsaPBonl8vP7Ym4tFPe+tAvGM0GbUoC24wYcloCG+J9hqmA==",
       "dev": true,
       "requires": {
         "cookie-es": "^0.5.0",
-        "destr": "^1.2.0",
-        "radix3": "^0.2.1",
-        "ufo": "^0.8.6"
+        "defu": "^6.1.2",
+        "destr": "^1.2.2",
+        "iron-webcrypto": "^0.6.0",
+        "radix3": "^1.0.1",
+        "ufo": "^1.1.1",
+        "uncrypto": "^0.1.2"
+      },
+      "dependencies": {
+        "ufo": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.1.tgz",
+          "integrity": "sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==",
+          "dev": true
+        }
       }
     },
     "has": {
@@ -29374,15 +29498,15 @@
       }
     },
     "ioredis": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.2.4.tgz",
-      "integrity": "sha512-qIpuAEt32lZJQ0XyrloCRdlEdUUNGG9i0UOk6zgzK6igyudNWqEBxfH6OlbnOOoBBvr1WB02mm8fR55CnikRng==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.1.tgz",
+      "integrity": "sha512-C+IBcMysM6v52pTLItYMeV4Hz7uriGtoJdz7SSBDX6u+zwSYGirLdQh3L7t/OItWITcw3gTFMjJReYUwS4zihg==",
       "dev": true,
       "requires": {
         "@ioredis/commands": "^1.1.1",
         "cluster-key-slot": "^1.1.0",
         "debug": "^4.3.4",
-        "denque": "^2.0.1",
+        "denque": "^2.1.0",
         "lodash.defaults": "^4.2.0",
         "lodash.isarguments": "^3.1.0",
         "redis-errors": "^1.2.0",
@@ -29430,6 +29554,12 @@
         "ufo": "^0.8.5",
         "xss": "^1.0.14"
       }
+    },
+    "iron-webcrypto": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-0.6.0.tgz",
+      "integrity": "sha512-WYgEQttulX/+JTv1BTJFYY3OsAb+ZnCuA53IjppZMyiRsVdGeEuZ/k4fJrg77Rzn0pp9/PgWtXUF+5HndDA5SQ==",
+      "dev": true
     },
     "is-absolute": {
       "version": "1.0.0",
@@ -31503,12 +31633,6 @@
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
       "integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw=="
     },
-    "mkdir": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/mkdir/-/mkdir-0.0.2.tgz",
-      "integrity": "sha512-98OnjcWaNEIRUJJe9rFoWlbkQ5n9z8F86wIPCrI961YEViiVybTuJln919WuuSHSnlrqXy0ELKCntoPy8C7lqg==",
-      "dev": true
-    },
     "mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -31938,6 +32062,31 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/objectFitPolyfill/-/objectFitPolyfill-2.3.5.tgz",
       "integrity": "sha512-8Quz071ZmGi0QWEG4xB3Bv5Lpw6K0Uca87FLoLMKMWjB6qIq9IyBegP3b/VLNxv2WYvIMGoeUQ+c6ibUkNa8TA=="
+    },
+    "ofetch": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.0.1.tgz",
+      "integrity": "sha512-icBz2JYfEpt+wZz1FRoGcrMigjNKjzvufE26m9+yUiacRQRHwnNlGRPiDnW4op7WX/MR6aniwS8xw8jyVelF2g==",
+      "dev": true,
+      "requires": {
+        "destr": "^1.2.2",
+        "node-fetch-native": "^1.0.2",
+        "ufo": "^1.1.0"
+      },
+      "dependencies": {
+        "node-fetch-native": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.1.0.tgz",
+          "integrity": "sha512-nl5goFCig93JZ9FIV8GHT9xpNqXbxQUzkOmKIMKmncsBH9jhg7qKex8hirpymkBFmNQ114chEEG5lS4wgK2I+Q==",
+          "dev": true
+        },
+        "ufo": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.1.tgz",
+          "integrity": "sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==",
+          "dev": true
+        }
+      }
     },
     "ohmyfetch": {
       "version": "0.4.21",
@@ -33041,9 +33190,9 @@
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
     },
     "radix3": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/radix3/-/radix3-0.2.1.tgz",
-      "integrity": "sha512-FnhArTl5Tq7dodiLeSPKrDUyCQuJqEncP8cKdyy399g8F/cz7GH6FmzA3Rkosu2IZMkpswFFwXfb2ERSiL06pg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.0.1.tgz",
+      "integrity": "sha512-y+AcwZ3HcUIGc9zGsNVf5+BY/LxL+z+4h4J3/pp8jxSmy1STaCocPS3qrj4tA5ehUSzqtqK+0Aygvz/r/8vy4g==",
       "dev": true
     },
     "randombytes": {
@@ -35095,6 +35244,12 @@
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg=="
     },
+    "uncrypto": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.2.tgz",
+      "integrity": "sha512-kuZwRKV615lEw/Xx3Iz56FKk3nOeOVGaVmw0eg+x4Mne28lCotNFbBhDW7dEBCBKyKbRQiCadEZeNAFPVC5cgw==",
+      "dev": true
+    },
     "underscore.string": {
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.6.tgz",
@@ -35283,22 +35438,22 @@
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
     },
     "unstorage": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-0.6.0.tgz",
-      "integrity": "sha512-X05PIq28pVNA1BypX6Y00YNqAsHM25MGemvpjHeYvwJ8/wg936GoO1YD+VdWlqm3LmVX4fNJ5tlC7uhXsMPgeg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.4.1.tgz",
+      "integrity": "sha512-ETLczXBd7sjJZuA3oIzaYwhMShiGlo7cGx01Ww23x2ehlk6WiRR1YsmjDBipoiGorq8pX1RRoMQFp/n3me7QOg==",
       "dev": true,
       "requires": {
-        "anymatch": "^3.1.2",
+        "anymatch": "^3.1.3",
         "chokidar": "^3.5.3",
-        "destr": "^1.1.1",
-        "h3": "^0.8.1",
-        "ioredis": "^5.2.3",
-        "listhen": "^0.3.4",
-        "mkdir": "^0.0.2",
+        "destr": "^1.2.2",
+        "h3": "^1.5.0",
+        "ioredis": "^5.3.1",
+        "listhen": "^1.0.3",
+        "lru-cache": "^7.18.3",
         "mri": "^1.2.0",
-        "ohmyfetch": "^0.4.19",
-        "ufo": "^0.8.6",
-        "ws": "^8.9.0"
+        "node-fetch-native": "^1.0.2",
+        "ofetch": "^1.0.1",
+        "ufo": "^1.1.1"
       },
       "dependencies": {
         "clipboardy": {
@@ -35318,26 +35473,44 @@
           "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
           "dev": true
         },
+        "get-port-please": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.0.1.tgz",
+          "integrity": "sha512-R5pcVO8Z1+pVDu8Ml3xaJCEkBiiy1VQN9za0YqH8GIi1nIqD4IzQhzY6dDzMRtdS1lyiGlucRzm8IN8wtLIXng==",
+          "dev": true
+        },
         "listhen": {
-          "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/listhen/-/listhen-0.3.5.tgz",
-          "integrity": "sha512-suyt79hNmCFeBIyftcLqLPfYiXeB795gSUWOJT7nspl2IvREY0Q9xvchLhekxvQ0KiOPvWoyALnc9Mxoelm0Pw==",
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/listhen/-/listhen-1.0.4.tgz",
+          "integrity": "sha512-r94k7kmXHb8e8wpv7+UP/qqhhD+j/9TgX19QKim2cEJuWCLwlTw+5BkCFmYyjhQ7Bt8KdVun/2DcD7MF2Fe3+g==",
           "dev": true,
           "requires": {
             "clipboardy": "^3.0.0",
             "colorette": "^2.0.19",
-            "defu": "^6.1.0",
-            "get-port-please": "^2.6.1",
+            "defu": "^6.1.2",
+            "get-port-please": "^3.0.1",
             "http-shutdown": "^1.2.2",
             "ip-regex": "^5.0.0",
             "node-forge": "^1.3.1",
-            "ufo": "^0.8.6"
+            "ufo": "^1.1.1"
           }
         },
-        "ws": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+        "lru-cache": {
+          "version": "7.18.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+          "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+          "dev": true
+        },
+        "node-fetch-native": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.1.0.tgz",
+          "integrity": "sha512-nl5goFCig93JZ9FIV8GHT9xpNqXbxQUzkOmKIMKmncsBH9jhg7qKex8hirpymkBFmNQ114chEEG5lS4wgK2I+Q==",
+          "dev": true
+        },
+        "ufo": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.1.tgz",
+          "integrity": "sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==",
           "dev": true
         }
       }

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -9,8 +9,8 @@
       "version": "3.6.0",
       "license": "MIT",
       "dependencies": {
-        "@netlify/functions": "^1.3.0",
-        "@netlify/ipx": "^1.3.3",
+        "@netlify/functions": "^1.4.0",
+        "@netlify/ipx": "^1.4.0",
         "abortcontroller-polyfill": "^1.7.3",
         "chalk": "^4.1.2",
         "co-body": "^6.1.0",
@@ -4462,9 +4462,9 @@
       }
     },
     "node_modules/@netlify/ipx": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@netlify/ipx/-/ipx-1.3.3.tgz",
-      "integrity": "sha512-2rDdCGPDPW7cyJr57rwfvpouOJx34CLDgfa2yfqTKvPzqCMOqkCi1PN/rHGuvJ/k5trZ8rxmWnnZyEbeQaZcqA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@netlify/ipx/-/ipx-1.4.0.tgz",
+      "integrity": "sha512-Ibqg1W41EVMHNT/W6JSDUyxjhcxsbEL9vL9ZaNjn9tVKnDYxJ8JqRTwSbzfns+K+M3FLqoC4PLW32qW+vT1pKQ==",
       "dependencies": {
         "@netlify/functions": "^1.4.0",
         "etag": "^1.8.1",
@@ -28769,9 +28769,9 @@
       }
     },
     "@netlify/ipx": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@netlify/ipx/-/ipx-1.3.3.tgz",
-      "integrity": "sha512-2rDdCGPDPW7cyJr57rwfvpouOJx34CLDgfa2yfqTKvPzqCMOqkCi1PN/rHGuvJ/k5trZ8rxmWnnZyEbeQaZcqA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@netlify/ipx/-/ipx-1.4.0.tgz",
+      "integrity": "sha512-Ibqg1W41EVMHNT/W6JSDUyxjhcxsbEL9vL9ZaNjn9tVKnDYxJ8JqRTwSbzfns+K+M3FLqoC4PLW32qW+vT1pKQ==",
       "requires": {
         "@netlify/functions": "^1.4.0",
         "etag": "^1.8.1",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@netlify/functions": "^1.4.0",
-    "@netlify/ipx": "^1.3.3",
+    "@netlify/ipx": "^1.4.0",
     "abortcontroller-polyfill": "^1.7.3",
     "chalk": "^4.1.2",
     "co-body": "^6.1.0",


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/frameworks as the Reviewer -->

### Summary

Just making sure we use latest `@netlify/ipx` (with https://github.com/netlify/netlify-ipx/pull/136 ). Current version range accept it, but package manager might still use older version if there is cached `node_modules` (or similar)

### Test plan

1. Visit the Deploy Preview ([insert link to specific page]()) ...

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was
published correctly.
