### PR TITLE
chore: add github workflow to add zenhub label to new issues

### DIFF
--- a/.github/workflows/add-zenhub-label.yml
+++ b/.github/workflows/add-zenhub-label.yml
@@ -1,0 +1,24 @@
+# Ensure we add the correct ZenHub label for all new issues
+# Avoids problem where checklist issues are not added to the correct ZenHub pipeline
+
+name: Add ZenHub label to issues
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["Ecosystem: Frameworks"]
+            })


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/frameworks as the Reviewer -->

### Summary

Adds `Ecosystem: Frameworks` label for all created issues to ensure it appears on the correct ZenHub workspace. Issues which are created using GitHub checklists didn't apply the issue template and the label was missing.

### Test plan

N/A

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

![image](https://github.com/netlify/netlify-plugin-gatsby/assets/1965510/6a5d21e5-4280-462d-b370-653fc51f40e4)

Related issue: https://github.com/netlify/pod-ecosystem-frameworks/issues/507

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [x] Check the Deploy Preview's Demo site for your PR's functionality
- [x] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was
published correctly.
