### PR TITLE
feat: skip work when gatsby version supports adapters

### DIFF
--- a/plugin/src/helpers/config.ts
+++ b/plugin/src/helpers/config.ts
@@ -15,7 +15,7 @@ import fs, {
 import type { GatsbyConfig, PluginRef } from 'gatsby'
 import { v4 as uuidv4 } from 'uuid'
 
-import { checkPackageVersion } from './files'
+import { checkPackageVersion, findModuleFromBase } from './files'
 import type { FunctionList } from './functions'
 
 /**
@@ -337,5 +337,42 @@ function isEnvSet(envVar: string) {
 
 export function getGatsbyRoot(publish: string): string {
   return resolve(dirname(publish))
+}
+
+export function shouldSkip(publishDir: string): boolean {
+  if (typeof process.env.NETLIFY_SKIP_GATSBY_BUILD_PLUGIN !== 'undefined') {
+    return isEnvSet('NETLIFY_SKIP_GATSBY_BUILD_PLUGIN')
+  }
+
+  const siteRoot = getGatsbyRoot(publishDir)
+
+  let shouldSkipResult = false
+
+  try {
+    const gatsbyPath = findModuleFromBase({
+      paths: [siteRoot],
+      candidates: ['gatsby/package.json'],
+    })
+    if (gatsbyPath) {
+      const gatsbyPluginUtilsPath = findModuleFromBase({
+        paths: [gatsbyPath, siteRoot],
+        candidates: ['gatsby-plugin-utils'],
+      })
+
+      // eslint-disable-next-line import/no-dynamic-require, n/global-require, @typescript-eslint/no-var-requires
+      const { hasFeature } = require(gatsbyPluginUtilsPath)
+
+      if (hasFeature(`adapters`)) {
+        shouldSkipResult = true
+      }
+    }
+  } catch {
+    // ignore
+  }
+
+  process.env.NETLIFY_SKIP_GATSBY_BUILD_PLUGIN = shouldSkipResult
+    ? 'true'
+    : 'false'
+  return shouldSkipResult
 }
 /* eslint-enable max-lines */


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/frameworks as the Reviewer -->

### Summary

This makes this build plugin no-op if Gatsby version supports adapters as all the handling will be done by adapter. Work on gatsby adapters can be tracked in https://github.com/gatsbyjs/gatsby/pull/38232

### Test plan

1. Visit the Deploy Preview ([insert link to specific page]()) ...

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was
published correctly.
