### PR TITLE
test: pin netlify-cli to 17.6.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           key:
             ubuntu-build-${{ env.cache-name }}-${{
             hashFiles('plugin/test/fixtures/**/package.json') }}-node-modules
-      - run: npm install -g netlify-cli
+      - run: npm install -g netlify-cli@17.6.0
       - run: npm ci
       - run: cd plugin && npm ci && npm run build
       - run: npm test


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/frameworks as the Reviewer -->

### Summary

There is some problem with latest CLI and our tests. Not clear yet where the problem actually is, but for now to unblock unrelated work let's pin (hopefully temporarily) CLI version we are using in tests, until we fix either the CLI or the tests

https://github.com/netlify/cli/pull/6180#issuecomment-1825919680 has a bit more information about the problem

### Test plan

1. Visit the Deploy Preview ([insert link to specific page]()) ...

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was
published correctly.
