### PR TITLE
fix: don't use peer deps - use regular deps

### DIFF
--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -9,11 +9,13 @@
       "version": "3.8.0",
       "license": "MIT",
       "dependencies": {
+        "@gatsbyjs/reach-router": "^2.0.0",
         "@netlify/functions": "^1.6.0",
         "@netlify/ipx": "^1.4.6",
         "abortcontroller-polyfill": "^1.7.3",
         "chalk": "^4.1.2",
         "co-body": "^6.1.0",
+        "common-tags": "^1.8.2",
         "cookie": "^0.6.0",
         "download": "^8.0.0",
         "etag": "^1.8.1",
@@ -30,7 +32,6 @@
         "uuid": "^9.0.0"
       },
       "devDependencies": {
-        "@gatsbyjs/reach-router": "^2.0.0",
         "@netlify/build": "^29.27.0",
         "@types/chance": "^1.1.3",
         "@types/fs-extra": "^9.0.12",
@@ -47,10 +48,6 @@
       },
       "engines": {
         "node": ">=14.17.0"
-      },
-      "peerDependencies": {
-        "@gatsbyjs/reach-router": "*",
-        "common-tags": "^1.8.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3116,7 +3113,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@gatsbyjs/reach-router/-/reach-router-2.0.1.tgz",
       "integrity": "sha512-gmSZniS9/phwgEgpFARMpNg21PkYDZEpfgEzvkgpE/iku4uvXqCrxr86fXbTpI9mkrhKS1SCTYmLGe60VdHcdQ==",
-      "dev": true,
       "dependencies": {
         "invariant": "^2.2.4",
         "prop-types": "^15.8.1"
@@ -11175,7 +11171,6 @@
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
       "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
-      "dev": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -17939,7 +17934,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
@@ -18737,8 +18731,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -19391,7 +19384,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -22401,7 +22393,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -22411,8 +22402,7 @@
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/proper-lockfile": {
       "version": "4.1.2",
@@ -28929,7 +28919,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@gatsbyjs/reach-router/-/reach-router-2.0.1.tgz",
       "integrity": "sha512-gmSZniS9/phwgEgpFARMpNg21PkYDZEpfgEzvkgpE/iku4uvXqCrxr86fXbTpI9mkrhKS1SCTYmLGe60VdHcdQ==",
-      "dev": true,
       "requires": {
         "invariant": "^2.2.4",
         "prop-types": "^15.8.1"
@@ -34733,8 +34722,7 @@
     "common-tags": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
-      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
-      "dev": true
+      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -39823,7 +39811,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -40401,8 +40388,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -40933,7 +40919,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -43082,7 +43067,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -43092,8 +43076,7 @@
         "react-is": {
           "version": "16.13.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-          "dev": true
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -40,11 +40,13 @@
     "prepare": "npm run build"
   },
   "dependencies": {
+    "@gatsbyjs/reach-router": "^2.0.0",
     "@netlify/functions": "^1.6.0",
     "@netlify/ipx": "^1.4.6",
     "abortcontroller-polyfill": "^1.7.3",
     "chalk": "^4.1.2",
     "co-body": "^6.1.0",
+    "common-tags": "^1.8.2",
     "cookie": "^0.6.0",
     "download": "^8.0.0",
     "etag": "^1.8.1",
@@ -61,7 +63,6 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
-    "@gatsbyjs/reach-router": "^2.0.0",
     "@netlify/build": "^29.27.0",
     "@types/chance": "^1.1.3",
     "@types/fs-extra": "^9.0.12",
@@ -75,9 +76,5 @@
     "rimraf": "^5.0.0",
     "tmp-promise": "^3.0.3",
     "typescript": "^5.0.0"
-  },
-  "peerDependencies": {
-    "@gatsbyjs/reach-router": "*",
-    "common-tags": "^1.8.2"
   }
 }

--- a/plugin/src/helpers/config.ts
+++ b/plugin/src/helpers/config.ts
@@ -231,7 +231,6 @@ export function mutateConfig({
   if (neededFunctions.includes('API')) {
     netlifyConfig.functions.__api = {
       included_files: [posix.join(cacheDir, 'functions', '**')],
-      external_node_modules: ['msgpackr-extract'],
       node_bundler: 'nft',
     }
   }

--- a/plugin/src/helpers/config.ts
+++ b/plugin/src/helpers/config.ts
@@ -232,7 +232,7 @@ export function mutateConfig({
     netlifyConfig.functions.__api = {
       included_files: [posix.join(cacheDir, 'functions', '**')],
       external_node_modules: ['msgpackr-extract'],
-      node_bundler: 'esbuild',
+      node_bundler: 'nft',
     }
   }
 

--- a/plugin/src/helpers/config.ts
+++ b/plugin/src/helpers/config.ts
@@ -232,6 +232,7 @@ export function mutateConfig({
     netlifyConfig.functions.__api = {
       included_files: [posix.join(cacheDir, 'functions', '**')],
       external_node_modules: ['msgpackr-extract'],
+      node_bundler: 'esbuild',
     }
   }
 

--- a/plugin/src/helpers/functions.ts
+++ b/plugin/src/helpers/functions.ts
@@ -39,7 +39,6 @@ const adjustRequiresToRelative = async (filesToAdjustRequires: Set<string>) => {
     const newContent = content.replace(
       /require\(["'`]([^"'`]+)["'`]\)/g,
       (match, request) => {
-        console.log({ match, request })
         if (request.startsWith('.')) {
           return match
         }
@@ -49,8 +48,9 @@ const adjustRequiresToRelative = async (filesToAdjustRequires: Set<string>) => {
           // for builtins path will be the same as request
           return match
         }
-        const relativePath = relative(dirname(file), absolutePath)
-        return `require('./${relativePath}')`
+        const relativePath = `./${relative(dirname(file), absolutePath)}`
+        console.log({ file, request, match, relativePath })
+        return `require('${relativePath}')`
       },
     )
 

--- a/plugin/src/helpers/functions.ts
+++ b/plugin/src/helpers/functions.ts
@@ -9,6 +9,11 @@ import { getGatsbyRoot } from './config'
 
 export type FunctionList = Array<'API' | 'SSR' | 'DSG'>
 
+/**
+ * Adjust package imports in functions we produce to be relative. Those imported packages should always be dependencies
+ * of `@netlify/plugin-gatsby` and we can't rely on those imports being resolvable by accident (i.e. npm hoisting deps
+ * of this plugin in root node_modules)
+ */
 export const adjustRequiresToRelative = (
   template: string,
   outputLocation: string,
@@ -25,7 +30,6 @@ export const adjustRequiresToRelative = (
       return match
     }
     const relativePath = `./${relative(dirname(outputLocation), absolutePath)}`
-    console.log({ outputLocation, request, match, relativePath })
     return `require('${relativePath}')`
   })
 

--- a/plugin/src/templates/api/gatsbyFunction.ts
+++ b/plugin/src/templates/api/gatsbyFunction.ts
@@ -2,10 +2,7 @@ import { existsSync } from 'fs'
 import path from 'path'
 import process from 'process'
 
-import {
-  match as reachRouterMatch,
-  matchPath as reachRouterMatchPath,
-} from '@gatsbyjs/reach-router'
+import { match as reachMatch } from '@gatsbyjs/reach-router'
 import { HandlerEvent } from '@netlify/functions'
 import bodyParser from 'co-body'
 import multer from 'multer'
@@ -16,11 +13,6 @@ import {
   AugmentedGatsbyFunctionRequest,
 } from './utils'
 
-/**
- * Depending on the version of '@gatsbyjs/reach-router' installed, the 'match' method may not be defined.
- * This check ensures that this continues to work as expected between v1 and v2 of the package.
- */
-const reachMatch = reachRouterMatch || reachRouterMatchPath
 const parseForm = multer().any()
 type MulterReq = Parameters<typeof parseForm>[0]
 type MulterRes = Parameters<typeof parseForm>[1]

--- a/plugin/src/templates/api/utils.ts
+++ b/plugin/src/templates/api/utils.ts
@@ -10,8 +10,7 @@ import {
   HandlerContext,
 } from '@netlify/functions'
 import cookie from 'cookie'
-import type { GatsbyFunctionResponse } from 'gatsby'
-import { GatsbyFunctionRequest } from 'gatsby'
+import type { GatsbyFunctionRequest, GatsbyFunctionResponse } from 'gatsby'
 import fetch, { Headers } from 'node-fetch'
 import statuses from 'statuses'
 

--- a/plugin/test/unit/helpers/config.spec.ts
+++ b/plugin/test/unit/helpers/config.spec.ts
@@ -106,7 +106,6 @@ describe('mutateConfig', () => {
 
     expect(netlifyConfig.functions.__api).toStrictEqual({
       included_files: [`${cacheDir}/functions/**`],
-      external_node_modules: ['msgpackr-extract'],
       node_bundler: 'nft',
     })
     expect(netlifyConfig.functions.__ssr).toStrictEqual(
@@ -133,7 +132,6 @@ describe('mutateConfig', () => {
 
     expect(netlifyConfig.functions.__api).toStrictEqual({
       included_files: [`${cacheDir}/functions/**`],
-      external_node_modules: ['msgpackr-extract'],
       node_bundler: 'nft',
     })
     expect(netlifyConfig.functions.__ssr).toStrictEqual(
@@ -158,7 +156,6 @@ describe('mutateConfig', () => {
 
     expect(netlifyConfig.functions.__api).toStrictEqual({
       included_files: [`${cacheDir}/functions/**`],
-      external_node_modules: ['msgpackr-extract'],
       node_bundler: 'nft',
     })
     expect(netlifyConfig.functions.__ssr).toStrictEqual(

--- a/plugin/test/unit/helpers/config.spec.ts
+++ b/plugin/test/unit/helpers/config.spec.ts
@@ -107,7 +107,7 @@ describe('mutateConfig', () => {
     expect(netlifyConfig.functions.__api).toStrictEqual({
       included_files: [`${cacheDir}/functions/**`],
       external_node_modules: ['msgpackr-extract'],
-      node_bundler: 'esbuild',
+      node_bundler: 'nft',
     })
     expect(netlifyConfig.functions.__ssr).toStrictEqual(
       netlifyConfig.functions.__dsg,
@@ -134,7 +134,7 @@ describe('mutateConfig', () => {
     expect(netlifyConfig.functions.__api).toStrictEqual({
       included_files: [`${cacheDir}/functions/**`],
       external_node_modules: ['msgpackr-extract'],
-      node_bundler: 'esbuild',
+      node_bundler: 'nft',
     })
     expect(netlifyConfig.functions.__ssr).toStrictEqual(
       netlifyConfig.functions.__dsg,
@@ -159,7 +159,7 @@ describe('mutateConfig', () => {
     expect(netlifyConfig.functions.__api).toStrictEqual({
       included_files: [`${cacheDir}/functions/**`],
       external_node_modules: ['msgpackr-extract'],
-      node_bundler: 'esbuild',
+      node_bundler: 'nft',
     })
     expect(netlifyConfig.functions.__ssr).toStrictEqual(
       netlifyConfig.functions.__dsg,

--- a/plugin/test/unit/helpers/config.spec.ts
+++ b/plugin/test/unit/helpers/config.spec.ts
@@ -107,6 +107,7 @@ describe('mutateConfig', () => {
     expect(netlifyConfig.functions.__api).toStrictEqual({
       included_files: [`${cacheDir}/functions/**`],
       external_node_modules: ['msgpackr-extract'],
+      node_bundler: 'esbuild',
     })
     expect(netlifyConfig.functions.__ssr).toStrictEqual(
       netlifyConfig.functions.__dsg,
@@ -133,6 +134,7 @@ describe('mutateConfig', () => {
     expect(netlifyConfig.functions.__api).toStrictEqual({
       included_files: [`${cacheDir}/functions/**`],
       external_node_modules: ['msgpackr-extract'],
+      node_bundler: 'esbuild',
     })
     expect(netlifyConfig.functions.__ssr).toStrictEqual(
       netlifyConfig.functions.__dsg,
@@ -157,6 +159,7 @@ describe('mutateConfig', () => {
     expect(netlifyConfig.functions.__api).toStrictEqual({
       included_files: [`${cacheDir}/functions/**`],
       external_node_modules: ['msgpackr-extract'],
+      node_bundler: 'esbuild',
     })
     expect(netlifyConfig.functions.__ssr).toStrictEqual(
       netlifyConfig.functions.__dsg,

--- a/plugin/test/unit/helpers/functions.spec.ts
+++ b/plugin/test/unit/helpers/functions.spec.ts
@@ -98,52 +98,38 @@ describe('setupImageCdn', () => {
 })
 
 describe('adjustRequiresToRelative', () => {
-  const mockLocation = join(
-    process.cwd(),
-    'demo',
-    '.netlify',
-    'functions-internal',
-    '__fn',
-    '__fn.js',
-  )
-
   it('skips node builtins', () => {
-    expect(adjustRequiresToRelative('require("fs")', mockLocation)).toBe(
+    expect(adjustRequiresToRelative('require("fs")', __filename)).toBe(
       'require("fs")',
     )
-    expect(adjustRequiresToRelative('require("node:fs")', mockLocation)).toBe(
+    expect(adjustRequiresToRelative('require("node:fs")', __filename)).toBe(
       'require("node:fs")',
     )
   })
 
   it('skips already relative', () => {
-    expect(adjustRequiresToRelative('require("./sibling")', mockLocation)).toBe(
+    expect(adjustRequiresToRelative('require("./sibling")', __filename)).toBe(
       'require("./sibling")',
     )
     expect(
-      adjustRequiresToRelative('require("./nested/foo")', mockLocation),
+      adjustRequiresToRelative('require("./nested/foo")', __filename),
     ).toBe('require("./nested/foo")')
-    expect(adjustRequiresToRelative('require("../parent")', mockLocation)).toBe(
+    expect(adjustRequiresToRelative('require("../parent")', __filename)).toBe(
       'require("../parent")',
     )
   })
 
   it('handles packages', () => {
-    expect(
-      adjustRequiresToRelative('require("node-fetch")', mockLocation),
-    ).toBe(
-      `require('./../../../../plugin/node_modules/node-fetch/lib/index.js')`,
+    expect(adjustRequiresToRelative('require("node-fetch")', __filename)).toBe(
+      `require('./../../../node_modules/node-fetch/lib/index.js')`,
     )
-    expect(adjustRequiresToRelative(`require('multer')`, mockLocation)).toBe(
-      `require('./../../../../plugin/node_modules/multer/index.js')`,
+    expect(adjustRequiresToRelative(`require('multer')`, __filename)).toBe(
+      `require('./../../../node_modules/multer/index.js')`,
     )
     expect(
-      adjustRequiresToRelative(
-        'require(`@gatsbyjs/reach-router`)',
-        mockLocation,
-      ),
+      adjustRequiresToRelative('require(`@gatsbyjs/reach-router`)', __filename),
     ).toBe(
-      `require('./../../../../plugin/node_modules/@gatsbyjs/reach-router/dist/index.js')`,
+      `require('./../../../node_modules/@gatsbyjs/reach-router/dist/index.js')`,
     )
   })
 })


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/frameworks as the Reviewer -->

### Summary

This removes peer deps usage of build plugin - those cause problems in autoinstallation scenarios with package managers that enforce strict dependencies / no hoisting scenarios (for example by default with pnpm)

### Test plan

1. Visit the Deploy Preview ([insert link to specific page]()) ...

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

https://linear.app/netlify/issue/COM-225/netlify-dev-fails-on-monorepo-setup#comment-a8eee1ec

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was
published correctly.
