### PR TITLE
fix: clear redirects/rewrites produced by previous builds and generate functions in ntl dev

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           key:
             ubuntu-build-${{ env.cache-name }}-${{
             hashFiles('plugin/test/fixtures/**/package.json') }}-node-modules
-      - run: npm install -g netlify-cli@17.6.0
+      - run: npm install -g netlify-cli
       - run: npm ci
       - run: cd plugin && npm ci && npm run build
       - run: npm test

--- a/plugin/src/helpers/config.ts
+++ b/plugin/src/helpers/config.ts
@@ -196,57 +196,51 @@ export async function createMetadataFileAndCopyDatastore(
   await writeJSON(`${cacheDir}/dataMetadata.json`, payload)
 }
 
-export async function modifyConfigDev({
-  netlifyConfig,
-}: {
-  netlifyConfig: NetlifyConfig
-}): Promise<void> {
-  const redirectsFileName = join(netlifyConfig.build.publish, '_redirects')
-  // removing redirects that possibly were added for builds previously
-  // DSG/SSR and API is fully handled by gatsby dev server
-  await spliceConfig({
-    startMarker: '# @netlify/plugin-gatsby redirects start',
-    endMarker: '# @netlify/plugin-gatsby redirects end',
-    contents: '',
-    fileName: redirectsFileName,
-  })
-  // this is a bit of a hack - gatsby-plugin-netlify appends redirects before @netlify/plugin-gatsby
-  // so we use gatsby-plugin-netlify marker as start and @netlify/plugin-gatsby start marker as end
-  await spliceConfig({
-    startMarker: '## Created with gatsby-plugin-netlify',
-    endMarker: '# @netlify/plugin-gatsby redirects start',
-    contents: '',
-    fileName: redirectsFileName,
-  })
-  // this removes redirects produced by adapters in newer gatsby versions
-  // while build plugin doesn't do any work during builds when adapters are used
-  // adapters don't have hooks for `develop` so they can't clean their redirects
-  // so build plugin is handling that as it still runs (just skips most of the work)
-  await spliceConfig({
-    startMarker: '# gatsby-adapter-netlify start',
-    endMarker: '# gatsby-adapter-netlify end',
-    contents: '',
-    fileName: redirectsFileName,
-  })
-}
-
 export async function modifyConfig({
   netlifyConfig,
   cacheDir,
   neededFunctions,
+  isDev,
 }: {
   netlifyConfig: NetlifyConfig
   cacheDir: string
   neededFunctions: FunctionList
+  isDev?: boolean
 }): Promise<void> {
   mutateConfig({ netlifyConfig, cacheDir, neededFunctions })
 
-  if (neededFunctions.includes('API')) {
+  const redirectsFileName = join(netlifyConfig.build.publish, '_redirects')
+
+  await spliceConfig({
+    startMarker: '# @netlify/plugin-gatsby redirects start',
+    endMarker: '# @netlify/plugin-gatsby redirects end',
+    contents: neededFunctions.includes('API')
+      ? '/api/* /.netlify/functions/__api 200'
+      : '',
+    fileName: redirectsFileName,
+  })
+
+  if (isDev) {
+    // removing redirects that possibly were added for builds previously
+    // DSG/SSR is fully handled by gatsby dev server and is not even produced in dev
+
+    // this is a bit of a hack - gatsby-plugin-netlify appends redirects before @netlify/plugin-gatsby
+    // so we use gatsby-plugin-netlify marker as start and @netlify/plugin-gatsby start marker as end
     await spliceConfig({
-      startMarker: '# @netlify/plugin-gatsby redirects start',
-      endMarker: '# @netlify/plugin-gatsby redirects end',
-      contents: '/api/* /.netlify/functions/__api 200',
-      fileName: join(netlifyConfig.build.publish, '_redirects'),
+      startMarker: '## Created with gatsby-plugin-netlify',
+      endMarker: '# @netlify/plugin-gatsby redirects start',
+      contents: '',
+      fileName: redirectsFileName,
+    })
+    // this removes redirects produced by adapters in newer gatsby versions
+    // while build plugin doesn't do any work during builds when adapters are used
+    // adapters don't have hooks for `develop` so they can't clean their redirects
+    // so build plugin is handling that as it still runs (just skips most of the work)
+    await spliceConfig({
+      startMarker: '# gatsby-adapter-netlify start',
+      endMarker: '# gatsby-adapter-netlify end',
+      contents: '',
+      fileName: redirectsFileName,
     })
   }
 }

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -13,6 +13,7 @@ import {
   checkConfig,
   getNeededFunctions,
   modifyConfig,
+  modifyConfigDev,
   shouldSkipBundlingDatastore,
   shouldSkip,
   checkNetlifyImageCdn,
@@ -45,6 +46,10 @@ export async function onPreBuild({
   await checkConfig({ utils, netlifyConfig })
 
   await checkNetlifyImageCdn({ netlifyConfig })
+}
+
+export async function onDev({ netlifyConfig }): Promise<void> {
+  await modifyConfigDev({ netlifyConfig })
 }
 
 export async function onBuild({

--- a/plugin/test/fixtures/v5/with-adapters/e2e-tests/test-helpers.js
+++ b/plugin/test/fixtures/v5/with-adapters/e2e-tests/test-helpers.js
@@ -117,9 +117,7 @@ exports.runTests = function runTests(env, host) {
         expect(result).toEqual({
           amIJSON: true,
         })
-        expect(res.headers.get('content-type')).toEqual(
-          'application/json; charset=utf-8',
-        )
+        expect(res.headers.get('content-type')).toEqual('application/json')
       })
       test(`returns json correctly via send`, async () => {
         const res = await fetchTwice(`${host}/api/i-am-json-too`)
@@ -128,18 +126,14 @@ exports.runTests = function runTests(env, host) {
         expect(result).toEqual({
           amIJSON: true,
         })
-        expect(res.headers.get('content-type')).toEqual(
-          'application/json; charset=utf-8',
-        )
+        expect(res.headers.get('content-type')).toEqual('application/json')
       })
       test(`returns boolean correctly via send`, async () => {
         const res = await fetchTwice(`${host}/api/i-am-false`)
         const result = await res.json()
 
         expect(result).toEqual(false)
-        expect(res.headers.get('content-type')).toEqual(
-          'application/json; charset=utf-8',
-        )
+        expect(res.headers.get('content-type')).toEqual('application/json')
       })
       test(`returns status correctly via send`, async () => {
         const res = await fetchTwice(`${host}/api/i-am-status`)

--- a/plugin/test/fixtures/v5/with-adapters/e2e-tests/test-helpers.js
+++ b/plugin/test/fixtures/v5/with-adapters/e2e-tests/test-helpers.js
@@ -117,7 +117,9 @@ exports.runTests = function runTests(env, host) {
         expect(result).toEqual({
           amIJSON: true,
         })
-        expect(res.headers.get('content-type')).toEqual('application/json')
+        expect(res.headers.get('content-type')).toEqual(
+          'application/json; charset=utf-8',
+        )
       })
       test(`returns json correctly via send`, async () => {
         const res = await fetchTwice(`${host}/api/i-am-json-too`)
@@ -126,14 +128,18 @@ exports.runTests = function runTests(env, host) {
         expect(result).toEqual({
           amIJSON: true,
         })
-        expect(res.headers.get('content-type')).toEqual('application/json')
+        expect(res.headers.get('content-type')).toEqual(
+          'application/json; charset=utf-8',
+        )
       })
       test(`returns boolean correctly via send`, async () => {
         const res = await fetchTwice(`${host}/api/i-am-false`)
         const result = await res.json()
 
         expect(result).toEqual(false)
-        expect(res.headers.get('content-type')).toEqual('application/json')
+        expect(res.headers.get('content-type')).toEqual(
+          'application/json; charset=utf-8',
+        )
       })
       test(`returns status correctly via send`, async () => {
         const res = await fetchTwice(`${host}/api/i-am-status`)


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/frameworks as the Reviewer -->

### Summary

Reverts https://github.com/netlify/netlify-plugin-gatsby/pull/724 + adds fixes needed:

`ntl dev` clears `.netlify/functions-internal` so we have to (re)generate them. Alternatively we could skip that and rely on gatsby dev server handling functions however this moves `ntl dev` further away from builds (+ there is some quirk with with CLI where `*/x-www-form-urlencoded` and `multipart/form-data` requests are not proxied to dev server at least currently).

This also clears out redirects produced by `gatsby-plugin-netlify` AND `gatsby-adapter-netlify` if builld happened before - those redirects would be for DSG/SSR functions that can't work in dev, because gatsby doesn't even produce engines in dev and DSG/SSR pages are handled just the same as SSG pages in dev

### Test plan

1. Visit the Deploy Preview ([insert link to specific page]()) ...

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

FRA-181

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was
published correctly.
