### PR TITLE
fix: use encrypted image cdn if possible for ipx and/or use allowed remote url list

### DIFF
--- a/demo-v5/package-lock.json
+++ b/demo-v5/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/slugify": "^1.1.2",
-        "gatsby": "5.14.1",
+        "gatsby": "5.11.0",
         "gatsby-plugin-image": "next",
         "gatsby-plugin-sharp": "next",
         "gatsby-source-filesystem": "next",
@@ -4732,19 +4732,6 @@
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
-    "node_modules/@sigmacomputing/babel-plugin-lodash": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@sigmacomputing/babel-plugin-lodash/-/babel-plugin-lodash-3.3.5.tgz",
-      "integrity": "sha512-VFhaHjlNzWyBtBm3YdqOwP8GbQHK7sWzXKpSUBTLjl2Zz6/9PwCK4qXZXI5CHpDjmvbouHUDbjrZP2KU5h6VQg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/types": "^7.0.0",
-        "glob": "^7.1.1",
-        "lodash": "^4.17.10",
-        "require-package-name": "^2.0.1"
-      }
-    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -6104,7 +6091,8 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -6188,14 +6176,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.1.tgz",
-      "integrity": "sha512-NN+fvwH/kV01dYUQ3PTOZns4LWtWhOFCAhQ/pHb88WQ1hNe5V/dvFwc4VJcDL11LT9xSX0QtsR8sWUuyOuOq7g==",
-      "license": "MIT",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/axobject-query": {
@@ -6364,6 +6349,18 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/babel-plugin-lodash": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz",
+      "integrity": "sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.0.0-beta.49",
+        "@babel/types": "^7.0.0-beta.49",
+        "glob": "^7.1.1",
+        "lodash": "^4.17.10",
+        "require-package-name": "^2.0.1"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -7588,12 +7585,14 @@
     "node_modules/colorette": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
-      "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ=="
+      "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
+      "dev": true
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -7784,10 +7783,9 @@
       }
     },
     "node_modules/content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "license": "MIT",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -8429,6 +8427,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -8819,9 +8818,9 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.5.tgz",
-      "integrity": "sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.4.2.tgz",
+      "integrity": "sha512-FKn/3oMiJjrOEOeUub2WCox6JhxBXq/Zn3fZOMCBxKnNYtsdKjxhl7yR3fZhM9PV+rdE75SU5SYMc+2PGzo+Tg==",
       "license": "MIT",
       "dependencies": {
         "@types/cookie": "^0.4.1",
@@ -8832,23 +8831,23 @@
         "cookie": "~0.4.1",
         "cors": "~2.8.5",
         "debug": "~4.3.1",
-        "engine.io-parser": "~5.2.1",
-        "ws": "~8.17.1"
+        "engine.io-parser": "~5.0.3",
+        "ws": "~8.11.0"
       },
       "engines": {
-        "node": ">=10.2.0"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/engine.io-client": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.4.tgz",
-      "integrity": "sha512-GeZeeRjpD2qf49cZQ0Wvh/8NJNfeXkXXcoGh+F77oEAgo9gUHwT1fCRxSNU+YEEaysOJTnsFHmM5oAcPy4ntvQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.4.0.tgz",
+      "integrity": "sha512-GyKPDyoEha+XZ7iEqam49vz6auPnNJ9ZBfy89f+rMMas8AuiMWOZ9PVzu8xb9ZC6rafUqiGHSCfu22ih66E+1g==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1",
-        "engine.io-parser": "~5.2.1",
-        "ws": "~8.17.1",
+        "engine.io-parser": "~5.0.3",
+        "ws": "~8.11.0",
         "xmlhttprequest-ssl": "~2.0.0"
       }
     },
@@ -8870,9 +8869,9 @@
       }
     },
     "node_modules/engine.io-parser": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
-      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.7.tgz",
+      "integrity": "sha512-P+jDFbvK6lE3n1OL+q9KuzdOFWkkZ/cMV9gol/SbVfpyqfvrfrFTOFJ6fQm2VC3PZHlU3QPhVwmbsCnauHF2MQ==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -10455,6 +10454,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
       "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -10606,9 +10606,9 @@
       }
     },
     "node_modules/gatsby": {
-      "version": "5.14.1",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-5.14.1.tgz",
-      "integrity": "sha512-xumIbDl0bk/Het+9wDQETNSHtkobXaeUQTciwzbT42RW/zIoPkKTjNzdDrWOBzzpmR0RU/qEnLa0udDhzS01Ww==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-5.11.0.tgz",
+      "integrity": "sha512-hGvMDQPzxBNr974sUSz02UbkmAX22tPdf/0gKU3MFfPPqJGcHZk/AdrerGr4klRH7RgotwSxQxsIvCv+kY44fg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -10635,34 +10635,33 @@
         "@parcel/cache": "2.8.3",
         "@parcel/core": "2.8.3",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
-        "@sigmacomputing/babel-plugin-lodash": "^3.3.5",
         "@types/http-proxy": "^1.17.11",
-        "@typescript-eslint/eslint-plugin": "^5.60.1",
-        "@typescript-eslint/parser": "^5.60.1",
-        "@vercel/webpack-asset-relocator-loader": "1.7.3",
+        "@typescript-eslint/eslint-plugin": "^5.59.8",
+        "@typescript-eslint/parser": "^5.59.8",
+        "@vercel/webpack-asset-relocator-loader": "^1.7.3",
         "acorn-loose": "^8.3.0",
         "acorn-walk": "^8.2.0",
         "address": "1.2.2",
         "anser": "^2.1.1",
         "autoprefixer": "^10.4.14",
-        "axios": "^1.6.4",
+        "axios": "^0.21.1",
         "babel-jsx-utils": "^1.1.0",
         "babel-loader": "^8.3.0",
         "babel-plugin-add-module-exports": "^1.0.4",
         "babel-plugin-dynamic-import-node": "^2.3.3",
-        "babel-plugin-remove-graphql-queries": "^5.14.0",
-        "babel-preset-gatsby": "^3.14.0",
+        "babel-plugin-lodash": "^3.3.4",
+        "babel-plugin-remove-graphql-queries": "^5.11.0",
+        "babel-preset-gatsby": "^3.11.0",
         "better-opn": "^2.1.1",
         "bluebird": "^3.7.2",
-        "body-parser": "1.20.3",
-        "browserslist": "^4.21.9",
+        "browserslist": "^4.21.7",
         "cache-manager": "^2.11.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
         "common-tags": "^1.8.2",
         "compression": "^1.7.4",
         "cookie": "^0.5.0",
-        "core-js": "^3.31.0",
+        "core-js": "^3.30.2",
         "cors": "^2.8.5",
         "css-loader": "^5.2.7",
         "css-minimizer-webpack-plugin": "^2.0.0",
@@ -10673,13 +10672,13 @@
         "detect-port": "^1.5.1",
         "devcert": "^1.2.2",
         "dotenv": "^8.6.0",
-        "enhanced-resolve": "^5.15.0",
+        "enhanced-resolve": "^5.14.1",
         "error-stack-parser": "^2.1.4",
         "eslint": "^7.32.0",
         "eslint-config-react-app": "^6.0.0",
         "eslint-plugin-flowtype": "^5.10.0",
         "eslint-plugin-import": "^2.27.5",
-        "eslint-plugin-jsx-a11y": "^6.8.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-webpack-plugin": "^2.7.0",
@@ -10692,26 +10691,27 @@
         "file-loader": "^6.2.0",
         "find-cache-dir": "^3.3.2",
         "fs-exists-cached": "1.0.0",
-        "fs-extra": "^11.2.0",
-        "gatsby-cli": "^5.14.0",
-        "gatsby-core-utils": "^4.14.0",
-        "gatsby-graphiql-explorer": "^3.14.0",
-        "gatsby-legacy-polyfills": "^3.14.0",
-        "gatsby-link": "^5.14.1",
-        "gatsby-page-utils": "^3.14.0",
-        "gatsby-parcel-config": "1.14.0",
-        "gatsby-plugin-page-creator": "^5.14.0",
-        "gatsby-plugin-typescript": "^5.14.0",
-        "gatsby-plugin-utils": "^4.14.0",
-        "gatsby-react-router-scroll": "^6.14.0",
-        "gatsby-script": "^2.14.0",
-        "gatsby-worker": "^2.14.0",
+        "fs-extra": "^11.1.1",
+        "gatsby-cli": "^5.11.0",
+        "gatsby-core-utils": "^4.11.0",
+        "gatsby-graphiql-explorer": "^3.11.0",
+        "gatsby-legacy-polyfills": "^3.11.0",
+        "gatsby-link": "^5.11.0",
+        "gatsby-page-utils": "^3.11.0",
+        "gatsby-parcel-config": "^1.11.0",
+        "gatsby-plugin-page-creator": "^5.11.0",
+        "gatsby-plugin-typescript": "^5.11.0",
+        "gatsby-plugin-utils": "^4.11.0",
+        "gatsby-react-router-scroll": "^6.11.0",
+        "gatsby-script": "^2.11.0",
+        "gatsby-telemetry": "^4.11.0",
+        "gatsby-worker": "^2.11.0",
         "glob": "^7.2.3",
         "globby": "^11.1.0",
         "got": "^11.8.6",
-        "graphql": "^16.7.1",
+        "graphql": "^16.6.0",
         "graphql-compose": "^9.0.10",
-        "graphql-http": "^1.19.0",
+        "graphql-http": "^1.18.0",
         "graphql-tag": "^2.12.6",
         "hasha": "^5.2.2",
         "invariant": "^2.2.4",
@@ -10720,7 +10720,6 @@
         "joi": "^17.9.2",
         "json-loader": "^0.5.7",
         "latest-version": "^7.0.0",
-        "linkfs": "^2.1.0",
         "lmdb": "2.5.3",
         "lodash": "^4.17.21",
         "meant": "^1.0.3",
@@ -10738,7 +10737,6 @@
         "opentracing": "^0.14.7",
         "p-defer": "^3.0.0",
         "parseurl": "^1.3.3",
-        "path-to-regexp": "0.1.10",
         "physical-cpu-count": "^2.0.0",
         "platform": "^1.3.6",
         "postcss": "^8.4.24",
@@ -10754,12 +10752,12 @@
         "redux": "4.2.1",
         "redux-thunk": "^2.4.2",
         "resolve-from": "^5.0.0",
-        "semver": "^7.5.3",
+        "semver": "^7.5.1",
         "shallow-compare": "^1.2.2",
         "signal-exit": "^3.0.7",
         "slugify": "^1.6.6",
-        "socket.io": "4.7.1",
-        "socket.io-client": "4.7.1",
+        "socket.io": "4.6.1",
+        "socket.io-client": "4.6.1",
         "stack-trace": "^0.0.10",
         "string-similarity": "^1.2.2",
         "strip-ansi": "^6.0.1",
@@ -10771,12 +10769,12 @@
         "type-of": "^2.0.1",
         "url-loader": "^4.1.1",
         "uuid": "^8.3.2",
-        "webpack": "^5.88.1",
-        "webpack-dev-middleware": "^5.3.4",
+        "webpack": "^5.85.0",
+        "webpack-dev-middleware": "^4.3.0",
         "webpack-merge": "^5.9.0",
-        "webpack-stats-plugin": "^1.1.3",
+        "webpack-stats-plugin": "^1.1.1",
         "webpack-virtual-modules": "^0.5.0",
-        "xstate": "^4.38.0",
+        "xstate": "^4.37.2",
         "yaml-loader": "^0.8.0"
       },
       "bin": {
@@ -10786,7 +10784,7 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "gatsby-sharp": "^1.14.0"
+        "gatsby-sharp": "^1.11.0"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^0.0.0",
@@ -11459,6 +11457,36 @@
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
+    "node_modules/gatsby-telemetry": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-4.14.0.tgz",
+      "integrity": "sha512-OvhbU3NxWYzmIdU2JX7xTCum5bm8S5AiZ3Z2Vl2U7GsQxx1BAU543yrHsRvcFqkX6diB+OXdEJUPaQyXmywMiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.18.6",
+        "@babel/runtime": "^7.20.13",
+        "fs-extra": "^11.2.0",
+        "gatsby-core-utils": "^4.14.0",
+        "git-up": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/gatsby-telemetry/node_modules/fs-extra": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/gatsby-transformer-remark": {
       "version": "6.3.0-next.0",
       "resolved": "https://registry.npmjs.org/gatsby-transformer-remark/-/gatsby-transformer-remark-6.3.0-next.0.tgz",
@@ -11523,54 +11551,6 @@
         "node": ">=14.14"
       }
     },
-    "node_modules/gatsby/node_modules/body-parser": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/gatsby/node_modules/body-parser/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/gatsby/node_modules/body-parser/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
-    "node_modules/gatsby/node_modules/bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/gatsby/node_modules/cookie": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
@@ -11621,42 +11601,6 @@
       },
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/gatsby/node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
-      "license": "MIT"
-    },
-    "node_modules/gatsby/node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.0.6"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/gatsby/node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/gatsby/node_modules/style-to-object": {
@@ -11777,6 +11721,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/git-up": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/git-up/-/git-up-7.0.0.tgz",
+      "integrity": "sha512-ONdIrbBCFusq1Oy0sC71F5azx8bVkvtZtMJAsv+a6lz5YAmbNnLD6HAB4gptHZVLPR8S2/kVN6Gab7lryq5+lQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-ssh": "^1.4.0",
+        "parse-url": "^8.1.0"
       }
     },
     "node_modules/github-from-package": {
@@ -11952,10 +11906,9 @@
       "license": "MIT"
     },
     "node_modules/graphql": {
-      "version": "16.10.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.10.0.tgz",
-      "integrity": "sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==",
-      "license": "MIT",
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -13325,6 +13278,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-ssh": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.0.tgz",
+      "integrity": "sha512-x7+VxdxOdlV3CYpjvRLBv5Lo9OJerlYanjwFrPR9fuGPjCiNiCzFgAWpiLAohSbsnH4ZAys3SBh+hq5rJosxUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocols": "^2.0.1"
+      }
+    },
     "node_modules/is-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -14556,7 +14518,8 @@
     "node_modules/linkfs": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/linkfs/-/linkfs-2.1.0.tgz",
-      "integrity": "sha512-kmsGcmpvjStZ0ATjuHycBujtNnXiZR28BTivEu0gAMDTT7GEyodcK6zSRtu6xsrdorrPZEIN380x7BD7xEYkew=="
+      "integrity": "sha512-kmsGcmpvjStZ0ATjuHycBujtNnXiZR28BTivEu0gAMDTT7GEyodcK6zSRtu6xsrdorrPZEIN380x7BD7xEYkew==",
+      "dev": true
     },
     "node_modules/listhen": {
       "version": "0.2.15",
@@ -14841,6 +14804,25 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dependencies": {
+        "p-defer": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/map-age-cleaner/node_modules/p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -15109,6 +15091,29 @@
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mem": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
+      "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
+      "dependencies": {
+        "map-age-cleaner": "^0.1.3",
+        "mimic-fn": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/mem?sponsor=1"
+      }
+    },
+    "node_modules/mem/node_modules/mimic-fn": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/memfs": {
@@ -16420,10 +16425,28 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/parse-path": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.0.0.tgz",
+      "integrity": "sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==",
+      "license": "MIT",
+      "dependencies": {
+        "protocols": "^2.0.0"
+      }
+    },
     "node_modules/parse-srcset": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
       "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
+    },
+    "node_modules/parse-url": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-8.1.0.tgz",
+      "integrity": "sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-path": "^7.0.0"
+      }
     },
     "node_modules/parse5": {
       "version": "6.0.1",
@@ -17492,6 +17515,12 @@
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="
     },
+    "node_modules/protocols": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz",
+      "integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==",
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -17508,6 +17537,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ps-tree": {
@@ -19062,18 +19092,17 @@
       }
     },
     "node_modules/socket.io": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.1.tgz",
-      "integrity": "sha512-W+utHys2w//dhFjy7iQQu9sGd3eokCjGbl2r59tyLqNiJJBdIebn3GAKEXBr3osqHTObJi2die/25bCx2zsaaw==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.6.1.tgz",
+      "integrity": "sha512-KMcaAi4l/8+xEjkRICl6ak8ySoxsYG+gG6/XfRCPJPQ/haCRIJBTL4wIl8YCsmtaBovcAXGLOShyVWQ/FG8GZA==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
-        "cors": "~2.8.5",
         "debug": "~4.3.2",
-        "engine.io": "~6.5.0",
+        "engine.io": "~6.4.1",
         "socket.io-adapter": "~2.5.2",
-        "socket.io-parser": "~4.2.4"
+        "socket.io-parser": "~4.2.1"
       },
       "engines": {
         "node": ">=10.0.0"
@@ -19106,16 +19135,37 @@
         }
       }
     },
+    "node_modules/socket.io-adapter/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/socket.io-client": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.1.tgz",
-      "integrity": "sha512-Qk3Xj8ekbnzKu3faejo4wk2MzXA029XppiXtTF/PkbTg+fcwaTw1PlDrTrrrU4mKoYC4dvlApOnSeyLCKwek2w==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.6.1.tgz",
+      "integrity": "sha512-5UswCV6hpaRsNg5kkEHVcbBIXEYoVbMQaHJBXJCyEQ+CiFPV1NIOY0XOFWG4XR4GZcB8Kn6AsRs/9cy9TbqVMQ==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.2",
-        "engine.io-client": "~6.5.1",
-        "socket.io-parser": "~4.2.4"
+        "engine.io-client": "~6.4.0",
+        "socket.io-parser": "~4.2.1"
       },
       "engines": {
         "node": ">=10.0.0"
@@ -21145,6 +21195,18 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/wait-on/node_modules/axios": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -21254,19 +21316,19 @@
       }
     },
     "node_modules/webpack-dev-middleware": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
-      "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
-      "license": "MIT",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-4.3.0.tgz",
+      "integrity": "sha512-PjwyVY95/bhBh6VUqt6z4THplYcsvQ8YNNBTBM873xLVmw8FLeALn0qurHbs9EmcfhzQis/eoqypSnZeuUz26w==",
       "dependencies": {
-        "colorette": "^2.0.10",
-        "memfs": "^3.4.3",
-        "mime-types": "^2.1.31",
+        "colorette": "^1.2.2",
+        "mem": "^8.1.1",
+        "memfs": "^3.2.2",
+        "mime-types": "^2.1.30",
         "range-parser": "^1.2.1",
-        "schema-utils": "^4.0.0"
+        "schema-utils": "^3.0.0"
       },
       "engines": {
-        "node": ">= 12.13.0"
+        "node": ">= v10.23.3"
       },
       "funding": {
         "type": "opencollective",
@@ -21276,58 +21338,10 @@
         "webpack": "^4.0.0 || ^5.0.0"
       }
     },
-    "node_modules/webpack-dev-middleware/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/webpack-dev-middleware/node_modules/ajv-keywords": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3"
-      },
-      "peerDependencies": {
-        "ajv": "^8.8.2"
-      }
-    },
-    "node_modules/webpack-dev-middleware/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
-    "node_modules/webpack-dev-middleware/node_modules/schema-utils": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
-      "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "ajv": "^8.9.0",
-        "ajv-formats": "^2.1.1",
-        "ajv-keywords": "^5.1.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
+    "node_modules/webpack-dev-middleware/node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="
     },
     "node_modules/webpack-merge": {
       "version": "5.10.0",
@@ -21361,10 +21375,9 @@
       }
     },
     "node_modules/webpack-stats-plugin": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/webpack-stats-plugin/-/webpack-stats-plugin-1.1.3.tgz",
-      "integrity": "sha512-yUKYyy+e0iF/w31QdfioRKY+h3jDBRpthexBOWGKda99iu2l/wxYsI/XqdlP5IU58/0KB9CsJZgWNAl+/MPkRw==",
-      "license": "MIT"
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webpack-stats-plugin/-/webpack-stats-plugin-1.1.1.tgz",
+      "integrity": "sha512-aWwE/YuO2W7VCOyWwyDJ7BRSYRYjeXat+X31YiasMM3FS6/4X9W4Mb9Q0g+jIdVgArr1Mb08sHBJKMT5M9+gVA=="
     },
     "node_modules/webpack-virtual-modules": {
       "version": "0.5.0",
@@ -21565,16 +21578,16 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
+        "utf-8-validate": "^5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {

--- a/demo-v5/package.json
+++ b/demo-v5/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@sindresorhus/slugify": "^1.1.2",
-    "gatsby": "5.14.1",
+    "gatsby": "5.11.0",
     "gatsby-plugin-image": "next",
     "gatsby-plugin-sharp": "next",
     "gatsby-source-filesystem": "next",

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -9343,9 +9343,9 @@
       }
     },
     "node_modules/gatsby": {
-      "version": "4.25.9",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-4.25.9.tgz",
-      "integrity": "sha512-/0/C4mesu+afcoQ+SCmTJQJrZLS7cUIgqotxPQ61+hhvE/DoU8j6a61qM1jOp1/Bwh+FQBpDXuFxGFAF3yNBig==",
+      "version": "4.25.7",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-4.25.7.tgz",
+      "integrity": "sha512-kspM1XokxDw2YqC2hkPKQTfWSNSq/AnY8PNYSrUM+MCsyIKFuGqSVchNonZN1g8/nCoh4jQpBYXH5Uw2Hrs6Sw==",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/code-frame": "^7.14.0",
@@ -9374,7 +9374,7 @@
         "@types/http-proxy": "^1.17.7",
         "@typescript-eslint/eslint-plugin": "^4.33.0",
         "@typescript-eslint/parser": "^4.33.0",
-        "@vercel/webpack-asset-relocator-loader": "1.7.3",
+        "@vercel/webpack-asset-relocator-loader": "^1.7.0",
         "acorn-loose": "^8.3.0",
         "acorn-walk": "^8.2.0",
         "address": "1.1.2",
@@ -26731,9 +26731,9 @@
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
     },
     "gatsby": {
-      "version": "4.25.9",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-4.25.9.tgz",
-      "integrity": "sha512-/0/C4mesu+afcoQ+SCmTJQJrZLS7cUIgqotxPQ61+hhvE/DoU8j6a61qM1jOp1/Bwh+FQBpDXuFxGFAF3yNBig==",
+      "version": "4.25.7",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-4.25.7.tgz",
+      "integrity": "sha512-kspM1XokxDw2YqC2hkPKQTfWSNSq/AnY8PNYSrUM+MCsyIKFuGqSVchNonZN1g8/nCoh4jQpBYXH5Uw2Hrs6Sw==",
       "requires": {
         "@babel/code-frame": "^7.14.0",
         "@babel/core": "^7.15.5",
@@ -26761,7 +26761,7 @@
         "@types/http-proxy": "^1.17.7",
         "@typescript-eslint/eslint-plugin": "^4.33.0",
         "@typescript-eslint/parser": "^4.33.0",
-        "@vercel/webpack-asset-relocator-loader": "1.7.3",
+        "@vercel/webpack-asset-relocator-loader": "^1.7.0",
         "acorn-loose": "^8.3.0",
         "acorn-walk": "^8.2.0",
         "address": "1.1.2",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -6760,19 +6760,6 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
       "dev": true
     },
-    "node_modules/@sigmacomputing/babel-plugin-lodash": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@sigmacomputing/babel-plugin-lodash/-/babel-plugin-lodash-3.3.5.tgz",
-      "integrity": "sha512-VFhaHjlNzWyBtBm3YdqOwP8GbQHK7sWzXKpSUBTLjl2Zz6/9PwCK4qXZXI5CHpDjmvbouHUDbjrZP2KU5h6VQg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/types": "^7.0.0",
-        "glob": "^7.1.1",
-        "lodash": "^4.17.10",
-        "require-package-name": "^2.0.1"
-      }
-    },
     "node_modules/@sindresorhus/is": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.3.0.tgz",
@@ -7045,9 +7032,9 @@
       "dev": true
     },
     "node_modules/@types/http-proxy": {
-      "version": "1.17.16",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.16.tgz",
-      "integrity": "sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==",
+      "version": "1.17.9",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.9.tgz",
+      "integrity": "sha512-QsbSjA/fSk7xB+UXlCT3wHBy5ai9wOcNDWwZAtud+jXhwOM3l+EYZh8Lng4+/6n8uar0J7xILzqftJdJ/Wdfkw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -8589,12 +8576,6 @@
       "integrity": "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==",
       "dev": true
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
-    },
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -8678,14 +8659,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.1.tgz",
-      "integrity": "sha512-NN+fvwH/kV01dYUQ3PTOZns4LWtWhOFCAhQ/pHb88WQ1hNe5V/dvFwc4VJcDL11LT9xSX0QtsR8sWUuyOuOq7g==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "dev": true,
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/axobject-query": {
@@ -8758,6 +8737,19 @@
       "dev": true,
       "dependencies": {
         "object.assign": "^4.1.0"
+      }
+    },
+    "node_modules/babel-plugin-lodash": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz",
+      "integrity": "sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.0.0-beta.49",
+        "@babel/types": "^7.0.0-beta.49",
+        "glob": "^7.1.1",
+        "lodash": "^4.17.10",
+        "require-package-name": "^2.0.1"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -10003,12 +9995,6 @@
       "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
       "dev": true
     },
-    "node_modules/colorette": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "dev": true
-    },
     "node_modules/colors-option": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/colors-option/-/colors-option-3.0.0.tgz",
@@ -10034,18 +10020,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/command-exists": {
@@ -10342,9 +10316,9 @@
       }
     },
     "node_modules/content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
@@ -10385,9 +10359,9 @@
       "dev": true
     },
     "node_modules/core-js": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.41.0.tgz",
-      "integrity": "sha512-SJ4/EHwS36QMJd6h/Rg+GyR4A5xE0FSI3eZ+iBVpfqf1x0eTSg1smWLHrA+2jQThZSh97fmSgFSU8B61nxosxA==",
+      "version": "3.25.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.5.tgz",
+      "integrity": "sha512-nbm6eZSjm+ZuBQxCUPQKQCoUEfFOXjUZ8dTTyikyKaWrTYmAVbykQfwsKE5dBK88u3QCkCrzsx/PPlKfhsvgpw==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -11067,13 +11041,10 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
       "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      },
       "engines": {
         "node": ">=0.11"
       },
@@ -11202,15 +11173,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
       "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ=="
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/delegates": {
       "version": "1.0.0",
@@ -11699,9 +11661,9 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.5.tgz",
-      "integrity": "sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.1.tgz",
+      "integrity": "sha512-ECceEFcAaNRybd3lsGQKas3ZlMVjN3cyWwMP25D2i0zWfyiytVbTpRPa34qrr+FHddtpBVOmq4H/DCv1O0lZRA==",
       "dev": true,
       "dependencies": {
         "@types/cookie": "^0.4.1",
@@ -11712,23 +11674,23 @@
         "cookie": "~0.4.1",
         "cors": "~2.8.5",
         "debug": "~4.3.1",
-        "engine.io-parser": "~5.2.1",
-        "ws": "~8.17.1"
+        "engine.io-parser": "~5.0.3",
+        "ws": "~8.2.3"
       },
       "engines": {
-        "node": ">=10.2.0"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/engine.io-client": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.4.tgz",
-      "integrity": "sha512-GeZeeRjpD2qf49cZQ0Wvh/8NJNfeXkXXcoGh+F77oEAgo9gUHwT1fCRxSNU+YEEaysOJTnsFHmM5oAcPy4ntvQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.2.3.tgz",
+      "integrity": "sha512-aXPtgF1JS3RuuKcpSrBtimSjYvrbhKW9froICH4s0F3XQWLxsKNxqzG39nnvQZQnva4CMvUK63T7shevxRyYHw==",
       "dev": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1",
-        "engine.io-parser": "~5.2.1",
-        "ws": "~8.17.1",
+        "engine.io-parser": "~5.0.3",
+        "ws": "~8.2.3",
         "xmlhttprequest-ssl": "~2.0.0"
       }
     },
@@ -11756,9 +11718,9 @@
       "dev": true
     },
     "node_modules/engine.io-parser": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
-      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.7.tgz",
+      "integrity": "sha512-P+jDFbvK6lE3n1OL+q9KuzdOFWkkZ/cMV9gol/SbVfpyqfvrfrFTOFJ6fQm2VC3PZHlU3QPhVwmbsCnauHF2MQ==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -13474,15 +13436,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/flat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "dev": true,
-      "bin": {
-        "flat": "cli.js"
-      }
-    },
     "node_modules/flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -13518,9 +13471,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
       "dev": true,
       "funding": [
         {
@@ -13690,21 +13643,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/form-data-encoder": {
@@ -13882,9 +13820,9 @@
       }
     },
     "node_modules/gatsby": {
-      "version": "5.14.1",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-5.14.1.tgz",
-      "integrity": "sha512-xumIbDl0bk/Het+9wDQETNSHtkobXaeUQTciwzbT42RW/zIoPkKTjNzdDrWOBzzpmR0RU/qEnLa0udDhzS01Ww==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-5.9.1.tgz",
+      "integrity": "sha512-TNMmFqRnEZBZsoecp11ZhSeYmgKV6QfPsl1f46I+DK7n3yNWMkMN4ZpKuCdH2gw98d2LgtU7nHWHCohr54eb6A==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -13902,60 +13840,59 @@
         "@graphql-codegen/add": "^3.2.3",
         "@graphql-codegen/core": "^2.6.8",
         "@graphql-codegen/plugin-helpers": "^2.7.2",
-        "@graphql-codegen/typescript": "^2.8.8",
-        "@graphql-codegen/typescript-operations": "^2.5.13",
-        "@graphql-tools/code-file-loader": "^7.3.23",
-        "@graphql-tools/load": "^7.8.14",
-        "@jridgewell/trace-mapping": "^0.3.18",
+        "@graphql-codegen/typescript": "^2.8.7",
+        "@graphql-codegen/typescript-operations": "^2.5.12",
+        "@graphql-tools/code-file-loader": "^7.3.16",
+        "@graphql-tools/load": "^7.8.10",
+        "@jridgewell/trace-mapping": "^0.3.17",
         "@nodelib/fs.walk": "^1.2.8",
         "@parcel/cache": "2.8.3",
         "@parcel/core": "2.8.3",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
-        "@sigmacomputing/babel-plugin-lodash": "^3.3.5",
-        "@types/http-proxy": "^1.17.11",
-        "@typescript-eslint/eslint-plugin": "^5.60.1",
-        "@typescript-eslint/parser": "^5.60.1",
-        "@vercel/webpack-asset-relocator-loader": "1.7.3",
+        "@types/http-proxy": "^1.17.9",
+        "@typescript-eslint/eslint-plugin": "^5.57.0",
+        "@typescript-eslint/parser": "^5.57.0",
+        "@vercel/webpack-asset-relocator-loader": "^1.7.3",
         "acorn-loose": "^8.3.0",
         "acorn-walk": "^8.2.0",
         "address": "1.2.2",
         "anser": "^2.1.1",
-        "autoprefixer": "^10.4.14",
-        "axios": "^1.6.4",
+        "autoprefixer": "^10.4.13",
+        "axios": "^0.21.1",
         "babel-jsx-utils": "^1.1.0",
         "babel-loader": "^8.3.0",
         "babel-plugin-add-module-exports": "^1.0.4",
         "babel-plugin-dynamic-import-node": "^2.3.3",
-        "babel-plugin-remove-graphql-queries": "^5.14.0",
-        "babel-preset-gatsby": "^3.14.0",
+        "babel-plugin-lodash": "^3.3.4",
+        "babel-plugin-remove-graphql-queries": "^5.9.0",
+        "babel-preset-gatsby": "^3.9.0",
         "better-opn": "^2.1.1",
         "bluebird": "^3.7.2",
-        "body-parser": "1.20.3",
-        "browserslist": "^4.21.9",
+        "browserslist": "^4.21.4",
         "cache-manager": "^2.11.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
         "common-tags": "^1.8.2",
         "compression": "^1.7.4",
         "cookie": "^0.5.0",
-        "core-js": "^3.31.0",
+        "core-js": "^3.22.3",
         "cors": "^2.8.5",
         "css-loader": "^5.2.7",
         "css-minimizer-webpack-plugin": "^2.0.0",
         "css.escape": "^1.5.1",
-        "date-fns": "^2.30.0",
+        "date-fns": "^2.29.3",
         "debug": "^4.3.4",
-        "deepmerge": "^4.3.1",
+        "deepmerge": "^4.3.0",
         "detect-port": "^1.5.1",
         "devcert": "^1.2.2",
         "dotenv": "^8.6.0",
-        "enhanced-resolve": "^5.15.0",
+        "enhanced-resolve": "^5.12.0",
         "error-stack-parser": "^2.1.4",
         "eslint": "^7.32.0",
         "eslint-config-react-app": "^6.0.0",
         "eslint-plugin-flowtype": "^5.10.0",
         "eslint-plugin-import": "^2.27.5",
-        "eslint-plugin-jsx-a11y": "^6.8.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-webpack-plugin": "^2.7.0",
@@ -13968,35 +13905,35 @@
         "file-loader": "^6.2.0",
         "find-cache-dir": "^3.3.2",
         "fs-exists-cached": "1.0.0",
-        "fs-extra": "^11.2.0",
-        "gatsby-cli": "^5.14.0",
-        "gatsby-core-utils": "^4.14.0",
-        "gatsby-graphiql-explorer": "^3.14.0",
-        "gatsby-legacy-polyfills": "^3.14.0",
-        "gatsby-link": "^5.14.1",
-        "gatsby-page-utils": "^3.14.0",
-        "gatsby-parcel-config": "1.14.0",
-        "gatsby-plugin-page-creator": "^5.14.0",
-        "gatsby-plugin-typescript": "^5.14.0",
-        "gatsby-plugin-utils": "^4.14.0",
-        "gatsby-react-router-scroll": "^6.14.0",
-        "gatsby-script": "^2.14.0",
-        "gatsby-worker": "^2.14.0",
+        "fs-extra": "^11.1.1",
+        "gatsby-cli": "^5.9.0",
+        "gatsby-core-utils": "^4.9.0",
+        "gatsby-graphiql-explorer": "^3.9.0",
+        "gatsby-legacy-polyfills": "^3.9.0",
+        "gatsby-link": "^5.9.0",
+        "gatsby-page-utils": "^3.9.0",
+        "gatsby-parcel-config": "1.9.0",
+        "gatsby-plugin-page-creator": "^5.9.0",
+        "gatsby-plugin-typescript": "^5.9.0",
+        "gatsby-plugin-utils": "^4.9.0",
+        "gatsby-react-router-scroll": "^6.9.0",
+        "gatsby-script": "^2.9.0",
+        "gatsby-telemetry": "^4.9.0",
+        "gatsby-worker": "^2.9.0",
         "glob": "^7.2.3",
         "globby": "^11.1.0",
         "got": "^11.8.6",
-        "graphql": "^16.7.1",
+        "graphql": "^16.6.0",
         "graphql-compose": "^9.0.10",
-        "graphql-http": "^1.19.0",
+        "graphql-http": "^1.13.0",
         "graphql-tag": "^2.12.6",
         "hasha": "^5.2.2",
         "invariant": "^2.2.4",
         "is-relative": "^1.0.0",
         "is-relative-url": "^3.0.0",
-        "joi": "^17.9.2",
+        "joi": "^17.7.0",
         "json-loader": "^0.5.7",
         "latest-version": "^7.0.0",
-        "linkfs": "^2.1.0",
         "lmdb": "2.5.3",
         "lodash": "^4.17.21",
         "meant": "^1.0.3",
@@ -14007,17 +13944,16 @@
         "mitt": "^1.2.0",
         "moment": "^2.29.4",
         "multer": "^1.4.5-lts.1",
-        "node-fetch": "^2.6.11",
+        "node-fetch": "^2.6.8",
         "node-html-parser": "^5.4.2",
         "normalize-path": "^3.0.0",
         "null-loader": "^4.0.1",
         "opentracing": "^0.14.7",
         "p-defer": "^3.0.0",
         "parseurl": "^1.3.3",
-        "path-to-regexp": "0.1.10",
         "physical-cpu-count": "^2.0.0",
         "platform": "^1.3.6",
-        "postcss": "^8.4.24",
+        "postcss": "^8.4.21",
         "postcss-flexbugs-fixes": "^5.0.2",
         "postcss-loader": "^5.3.0",
         "prompts": "^2.4.2",
@@ -14030,29 +13966,28 @@
         "redux": "4.2.1",
         "redux-thunk": "^2.4.2",
         "resolve-from": "^5.0.0",
-        "semver": "^7.5.3",
+        "semver": "^7.3.8",
         "shallow-compare": "^1.2.2",
         "signal-exit": "^3.0.7",
-        "slugify": "^1.6.6",
-        "socket.io": "4.7.1",
-        "socket.io-client": "4.7.1",
+        "slugify": "^1.6.5",
+        "socket.io": "4.5.4",
+        "socket.io-client": "4.5.4",
         "stack-trace": "^0.0.10",
         "string-similarity": "^1.2.2",
         "strip-ansi": "^6.0.1",
         "style-loader": "^2.0.0",
-        "style-to-object": "^0.4.1",
-        "terser-webpack-plugin": "^5.3.9",
+        "terser-webpack-plugin": "^5.3.6",
         "tmp": "^0.2.1",
         "true-case-path": "^2.2.1",
         "type-of": "^2.0.1",
         "url-loader": "^4.1.1",
         "uuid": "^8.3.2",
-        "webpack": "^5.88.1",
-        "webpack-dev-middleware": "^5.3.4",
-        "webpack-merge": "^5.9.0",
-        "webpack-stats-plugin": "^1.1.3",
+        "webpack": "^5.75.0",
+        "webpack-dev-middleware": "^4.3.0",
+        "webpack-merge": "^5.8.0",
+        "webpack-stats-plugin": "^1.1.1",
         "webpack-virtual-modules": "^0.5.0",
-        "xstate": "^4.38.0",
+        "xstate": "^4.35.3",
         "yaml-loader": "^0.8.0"
       },
       "bin": {
@@ -14062,7 +13997,7 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "gatsby-sharp": "^1.14.0"
+        "gatsby-sharp": "^1.9.0"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^0.0.0",
@@ -14468,12 +14403,12 @@
       }
     },
     "node_modules/gatsby-parcel-config": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/gatsby-parcel-config/-/gatsby-parcel-config-1.14.0.tgz",
-      "integrity": "sha512-S7RQOo1O5wzHxHB1AHh4xKbg8Jj76VPbSMfVsVVapL2Ht7p1zxrZ7p2pOX3pr5WJnfacREOQwLhlk8rk8TDbGw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/gatsby-parcel-config/-/gatsby-parcel-config-1.9.0.tgz",
+      "integrity": "sha512-5wclOXzeI6HmH5iEYvqzLnt/kc0cnqlIObRmQE2zpV0xs9YTPXAH7GdnaheYKN8kibF1EWuBKJF79dv99/nGHg==",
       "dev": true,
       "dependencies": {
-        "@gatsbyjs/parcel-namer-relative-to-cwd": "2.14.0",
+        "@gatsbyjs/parcel-namer-relative-to-cwd": "^2.9.0",
         "@parcel/bundler-default": "2.8.3",
         "@parcel/compressor-raw": "2.8.3",
         "@parcel/namer-default": "2.8.3",
@@ -14664,6 +14599,18 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/gatsby-plugin-utils/node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/gatsby-react-router-scroll": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-6.14.0.tgz",
@@ -14706,6 +14653,36 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/gatsby-telemetry": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-4.14.0.tgz",
+      "integrity": "sha512-OvhbU3NxWYzmIdU2JX7xTCum5bm8S5AiZ3Z2Vl2U7GsQxx1BAU543yrHsRvcFqkX6diB+OXdEJUPaQyXmywMiA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.18.6",
+        "@babel/runtime": "^7.20.13",
+        "fs-extra": "^11.2.0",
+        "gatsby-core-utils": "^4.14.0",
+        "git-up": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/gatsby-telemetry/node_modules/fs-extra": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/gatsby-worker": {
@@ -14765,45 +14742,6 @@
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
-    },
-    "node_modules/gatsby/node_modules/body-parser": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
-      "dev": true,
-      "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/gatsby/node_modules/body-parser/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/gatsby/node_modules/body-parser/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
     },
     "node_modules/gatsby/node_modules/cacheable-lookup": {
       "version": "5.0.4",
@@ -14899,32 +14837,23 @@
         "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
+    "node_modules/gatsby/node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/gatsby/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
-    },
-    "node_modules/gatsby/node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
-      "dev": true
-    },
-    "node_modules/gatsby/node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-      "dev": true,
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/gatsby/node_modules/strip-ansi": {
       "version": "6.0.1",
@@ -15115,6 +15044,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/git-up": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/git-up/-/git-up-7.0.0.tgz",
+      "integrity": "sha512-ONdIrbBCFusq1Oy0sC71F5azx8bVkvtZtMJAsv+a6lz5YAmbNnLD6HAB4gptHZVLPR8S2/kVN6Gab7lryq5+lQ==",
+      "dev": true,
+      "dependencies": {
+        "is-ssh": "^1.4.0",
+        "parse-url": "^8.1.0"
       }
     },
     "node_modules/github-from-package": {
@@ -15431,9 +15370,9 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "16.10.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.10.0.tgz",
-      "integrity": "sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==",
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -15996,12 +15935,6 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
-    },
-    "node_modules/inline-style-parser": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
-      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==",
-      "dev": true
     },
     "node_modules/inquirer": {
       "version": "7.3.3",
@@ -16720,6 +16653,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-ssh": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.0.tgz",
+      "integrity": "sha512-x7+VxdxOdlV3CYpjvRLBv5Lo9OJerlYanjwFrPR9fuGPjCiNiCzFgAWpiLAohSbsnH4ZAys3SBh+hq5rJosxUQ==",
+      "dev": true,
+      "dependencies": {
+        "protocols": "^2.0.1"
       }
     },
     "node_modules/is-stream": {
@@ -17792,6 +17734,27 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
+    "node_modules/map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dev": true,
+      "dependencies": {
+        "p-defer": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/map-age-cleaner/node_modules/p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -17839,6 +17802,31 @@
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mem": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
+      "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
+      "dev": true,
+      "dependencies": {
+        "map-age-cleaner": "^0.1.3",
+        "mimic-fn": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/mem?sponsor=1"
+      }
+    },
+    "node_modules/mem/node_modules/mimic-fn": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/memfs": {
@@ -17962,17 +17950,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/mime": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -18287,9 +18264,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
       "dev": true,
       "funding": [
         {
@@ -19320,6 +19297,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-path": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.0.0.tgz",
+      "integrity": "sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==",
+      "dev": true,
+      "dependencies": {
+        "protocols": "^2.0.0"
+      }
+    },
+    "node_modules/parse-url": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-8.1.0.tgz",
+      "integrity": "sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==",
+      "dev": true,
+      "dependencies": {
+        "parse-path": "^7.0.0"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -19700,9 +19695,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.4.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.23.tgz",
+      "integrity": "sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==",
       "dev": true,
       "funding": [
         {
@@ -19719,9 +19714,9 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.8",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -20459,6 +20454,12 @@
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true
     },
+    "node_modules/protocols": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz",
+      "integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==",
+      "dev": true
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -20471,12 +20472,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
     },
     "node_modules/ps-list": {
       "version": "8.1.0",
@@ -20515,11 +20510,11 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.0.4"
       },
       "engines": {
         "node": ">=0.6"
@@ -22159,9 +22154,9 @@
       }
     },
     "node_modules/slugify": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
-      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
+      "integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ==",
       "dev": true,
       "engines": {
         "node": ">=8.0.0"
@@ -22178,66 +22173,38 @@
       }
     },
     "node_modules/socket.io": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.1.tgz",
-      "integrity": "sha512-W+utHys2w//dhFjy7iQQu9sGd3eokCjGbl2r59tyLqNiJJBdIebn3GAKEXBr3osqHTObJi2die/25bCx2zsaaw==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.4.tgz",
+      "integrity": "sha512-m3GC94iK9MfIEeIBfbhJs5BqFibMtkRk8ZpKwG2QwxV0m/eEhPIV4ara6XCF1LWNAus7z58RodiZlAH71U3EhQ==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
-        "cors": "~2.8.5",
         "debug": "~4.3.2",
-        "engine.io": "~6.5.0",
-        "socket.io-adapter": "~2.5.2",
-        "socket.io-parser": "~4.2.4"
+        "engine.io": "~6.2.1",
+        "socket.io-adapter": "~2.4.0",
+        "socket.io-parser": "~4.2.1"
       },
       "engines": {
         "node": ">=10.0.0"
       }
     },
     "node_modules/socket.io-adapter": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
-      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
-      "dev": true,
-      "dependencies": {
-        "debug": "~4.3.4",
-        "ws": "~8.17.1"
-      }
-    },
-    "node_modules/socket.io-adapter/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/socket.io-adapter/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz",
+      "integrity": "sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==",
       "dev": true
     },
     "node_modules/socket.io-client": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.1.tgz",
-      "integrity": "sha512-Qk3Xj8ekbnzKu3faejo4wk2MzXA029XppiXtTF/PkbTg+fcwaTw1PlDrTrrrU4mKoYC4dvlApOnSeyLCKwek2w==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.5.4.tgz",
+      "integrity": "sha512-ZpKteoA06RzkD32IbqILZ+Cnst4xewU7ZYK12aS1mzHftFFjpoMz69IuhP/nL25pJfao/amoPI527KnuhFm01g==",
       "dev": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.2",
-        "engine.io-client": "~6.5.1",
-        "socket.io-parser": "~4.2.4"
+        "engine.io-client": "~6.2.3",
+        "socket.io-parser": "~4.2.1"
       },
       "engines": {
         "node": ">=10.0.0"
@@ -22329,9 +22296,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -22775,15 +22742,6 @@
       },
       "peerDependencies": {
         "webpack": "^4.0.0 || ^5.0.0"
-      }
-    },
-    "node_modules/style-to-object": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.4.tgz",
-      "integrity": "sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==",
-      "dev": true,
-      "dependencies": {
-        "inline-style-parser": "0.1.1"
       }
     },
     "node_modules/stylehacks": {
@@ -23706,6 +23664,17 @@
         "pathe": "^1.1.1"
       }
     },
+    "node_modules/unenv/node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/unenv/node_modules/pathe": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.1.tgz",
@@ -24192,19 +24161,20 @@
       }
     },
     "node_modules/webpack-dev-middleware": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
-      "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-4.3.0.tgz",
+      "integrity": "sha512-PjwyVY95/bhBh6VUqt6z4THplYcsvQ8YNNBTBM873xLVmw8FLeALn0qurHbs9EmcfhzQis/eoqypSnZeuUz26w==",
       "dev": true,
       "dependencies": {
-        "colorette": "^2.0.10",
-        "memfs": "^3.4.3",
-        "mime-types": "^2.1.31",
+        "colorette": "^1.2.2",
+        "mem": "^8.1.1",
+        "memfs": "^3.2.2",
+        "mime-types": "^2.1.30",
         "range-parser": "^1.2.1",
-        "schema-utils": "^4.0.0"
+        "schema-utils": "^3.0.0"
       },
       "engines": {
-        "node": ">= 12.13.0"
+        "node": ">= v10.23.3"
       },
       "funding": {
         "type": "opencollective",
@@ -24214,67 +24184,19 @@
         "webpack": "^4.0.0 || ^5.0.0"
       }
     },
-    "node_modules/webpack-dev-middleware/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/webpack-dev-middleware/node_modules/ajv-keywords": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3"
-      },
-      "peerDependencies": {
-        "ajv": "^8.8.2"
-      }
-    },
-    "node_modules/webpack-dev-middleware/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+    "node_modules/webpack-dev-middleware/node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
       "dev": true
     },
-    "node_modules/webpack-dev-middleware/node_modules/schema-utils": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
-      "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "ajv": "^8.9.0",
-        "ajv-formats": "^2.1.1",
-        "ajv-keywords": "^5.1.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
     "node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
+      "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
       "dev": true,
       "dependencies": {
         "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
         "wildcard": "^2.0.0"
       },
       "engines": {
@@ -24678,16 +24600,16 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
+        "utf-8-validate": "^5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -29555,19 +29477,6 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
       "dev": true
     },
-    "@sigmacomputing/babel-plugin-lodash": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@sigmacomputing/babel-plugin-lodash/-/babel-plugin-lodash-3.3.5.tgz",
-      "integrity": "sha512-VFhaHjlNzWyBtBm3YdqOwP8GbQHK7sWzXKpSUBTLjl2Zz6/9PwCK4qXZXI5CHpDjmvbouHUDbjrZP2KU5h6VQg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/types": "^7.0.0",
-        "glob": "^7.1.1",
-        "lodash": "^4.17.10",
-        "require-package-name": "^2.0.1"
-      }
-    },
     "@sindresorhus/is": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.3.0.tgz",
@@ -29815,9 +29724,9 @@
       "dev": true
     },
     "@types/http-proxy": {
-      "version": "1.17.16",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.16.tgz",
-      "integrity": "sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==",
+      "version": "1.17.9",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.9.tgz",
+      "integrity": "sha512-QsbSjA/fSk7xB+UXlCT3wHBy5ai9wOcNDWwZAtud+jXhwOM3l+EYZh8Lng4+/6n8uar0J7xILzqftJdJ/Wdfkw==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -30994,12 +30903,6 @@
       "integrity": "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==",
       "dev": true
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
-    },
     "at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -31042,14 +30945,12 @@
       "dev": true
     },
     "axios": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.1.tgz",
-      "integrity": "sha512-NN+fvwH/kV01dYUQ3PTOZns4LWtWhOFCAhQ/pHb88WQ1hNe5V/dvFwc4VJcDL11LT9xSX0QtsR8sWUuyOuOq7g==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "dev": true,
       "requires": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.14.0"
       }
     },
     "axobject-query": {
@@ -31107,6 +31008,19 @@
       "dev": true,
       "requires": {
         "object.assign": "^4.1.0"
+      }
+    },
+    "babel-plugin-lodash": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz",
+      "integrity": "sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0-beta.49",
+        "@babel/types": "^7.0.0-beta.49",
+        "glob": "^7.1.1",
+        "lodash": "^4.17.10",
+        "require-package-name": "^2.0.1"
       }
     },
     "babel-plugin-macros": {
@@ -32028,12 +31942,6 @@
       "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
       "dev": true
     },
-    "colorette": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "dev": true
-    },
     "colors-option": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/colors-option/-/colors-option-3.0.0.tgz",
@@ -32052,15 +31960,6 @@
           "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
           "dev": true
         }
-      }
-    },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "requires": {
-        "delayed-stream": "~1.0.0"
       }
     },
     "command-exists": {
@@ -32309,9 +32208,9 @@
       }
     },
     "content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
     },
     "convert-hrtime": {
@@ -32343,9 +32242,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.41.0.tgz",
-      "integrity": "sha512-SJ4/EHwS36QMJd6h/Rg+GyR4A5xE0FSI3eZ+iBVpfqf1x0eTSg1smWLHrA+2jQThZSh97fmSgFSU8B61nxosxA==",
+      "version": "3.25.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.5.tgz",
+      "integrity": "sha512-nbm6eZSjm+ZuBQxCUPQKQCoUEfFOXjUZ8dTTyikyKaWrTYmAVbykQfwsKE5dBK88u3QCkCrzsx/PPlKfhsvgpw==",
       "dev": true
     },
     "core-js-compat": {
@@ -32815,13 +32714,10 @@
       }
     },
     "date-fns": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.21.0"
-      }
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
+      "dev": true
     },
     "debug": {
       "version": "3.2.7",
@@ -32907,12 +32803,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
       "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ=="
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -33295,9 +33185,9 @@
       }
     },
     "engine.io": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.5.tgz",
-      "integrity": "sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.1.tgz",
+      "integrity": "sha512-ECceEFcAaNRybd3lsGQKas3ZlMVjN3cyWwMP25D2i0zWfyiytVbTpRPa34qrr+FHddtpBVOmq4H/DCv1O0lZRA==",
       "dev": true,
       "requires": {
         "@types/cookie": "^0.4.1",
@@ -33308,8 +33198,8 @@
         "cookie": "~0.4.1",
         "cors": "~2.8.5",
         "debug": "~4.3.1",
-        "engine.io-parser": "~5.2.1",
-        "ws": "~8.17.1"
+        "engine.io-parser": "~5.0.3",
+        "ws": "~8.2.3"
       },
       "dependencies": {
         "cookie": {
@@ -33336,15 +33226,15 @@
       }
     },
     "engine.io-client": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.4.tgz",
-      "integrity": "sha512-GeZeeRjpD2qf49cZQ0Wvh/8NJNfeXkXXcoGh+F77oEAgo9gUHwT1fCRxSNU+YEEaysOJTnsFHmM5oAcPy4ntvQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.2.3.tgz",
+      "integrity": "sha512-aXPtgF1JS3RuuKcpSrBtimSjYvrbhKW9froICH4s0F3XQWLxsKNxqzG39nnvQZQnva4CMvUK63T7shevxRyYHw==",
       "dev": true,
       "requires": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1",
-        "engine.io-parser": "~5.2.1",
-        "ws": "~8.17.1",
+        "engine.io-parser": "~5.0.3",
+        "ws": "~8.2.3",
         "xmlhttprequest-ssl": "~2.0.0"
       },
       "dependencies": {
@@ -33366,9 +33256,9 @@
       }
     },
     "engine.io-parser": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
-      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.7.tgz",
+      "integrity": "sha512-P+jDFbvK6lE3n1OL+q9KuzdOFWkkZ/cMV9gol/SbVfpyqfvrfrFTOFJ6fQm2VC3PZHlU3QPhVwmbsCnauHF2MQ==",
       "dev": true
     },
     "enhanced-resolve": {
@@ -34635,12 +34525,6 @@
       "integrity": "sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==",
       "dev": true
     },
-    "flat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "dev": true
-    },
     "flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -34669,9 +34553,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
       "dev": true
     },
     "for-each": {
@@ -34779,18 +34663,6 @@
           "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
           "dev": true
         }
-      }
-    },
-    "form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
-      "dev": true,
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "mime-types": "^2.1.12"
       }
     },
     "form-data-encoder": {
@@ -34923,9 +34795,9 @@
       "dev": true
     },
     "gatsby": {
-      "version": "5.14.1",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-5.14.1.tgz",
-      "integrity": "sha512-xumIbDl0bk/Het+9wDQETNSHtkobXaeUQTciwzbT42RW/zIoPkKTjNzdDrWOBzzpmR0RU/qEnLa0udDhzS01Ww==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-5.9.1.tgz",
+      "integrity": "sha512-TNMmFqRnEZBZsoecp11ZhSeYmgKV6QfPsl1f46I+DK7n3yNWMkMN4ZpKuCdH2gw98d2LgtU7nHWHCohr54eb6A==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
@@ -34942,60 +34814,59 @@
         "@graphql-codegen/add": "^3.2.3",
         "@graphql-codegen/core": "^2.6.8",
         "@graphql-codegen/plugin-helpers": "^2.7.2",
-        "@graphql-codegen/typescript": "^2.8.8",
-        "@graphql-codegen/typescript-operations": "^2.5.13",
-        "@graphql-tools/code-file-loader": "^7.3.23",
-        "@graphql-tools/load": "^7.8.14",
-        "@jridgewell/trace-mapping": "^0.3.18",
+        "@graphql-codegen/typescript": "^2.8.7",
+        "@graphql-codegen/typescript-operations": "^2.5.12",
+        "@graphql-tools/code-file-loader": "^7.3.16",
+        "@graphql-tools/load": "^7.8.10",
+        "@jridgewell/trace-mapping": "^0.3.17",
         "@nodelib/fs.walk": "^1.2.8",
         "@parcel/cache": "2.8.3",
         "@parcel/core": "2.8.3",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
-        "@sigmacomputing/babel-plugin-lodash": "^3.3.5",
-        "@types/http-proxy": "^1.17.11",
-        "@typescript-eslint/eslint-plugin": "^5.60.1",
-        "@typescript-eslint/parser": "^5.60.1",
-        "@vercel/webpack-asset-relocator-loader": "1.7.3",
+        "@types/http-proxy": "^1.17.9",
+        "@typescript-eslint/eslint-plugin": "^5.57.0",
+        "@typescript-eslint/parser": "^5.57.0",
+        "@vercel/webpack-asset-relocator-loader": "^1.7.3",
         "acorn-loose": "^8.3.0",
         "acorn-walk": "^8.2.0",
         "address": "1.2.2",
         "anser": "^2.1.1",
-        "autoprefixer": "^10.4.14",
-        "axios": "^1.6.4",
+        "autoprefixer": "^10.4.13",
+        "axios": "^0.21.1",
         "babel-jsx-utils": "^1.1.0",
         "babel-loader": "^8.3.0",
         "babel-plugin-add-module-exports": "^1.0.4",
         "babel-plugin-dynamic-import-node": "^2.3.3",
-        "babel-plugin-remove-graphql-queries": "^5.14.0",
-        "babel-preset-gatsby": "^3.14.0",
+        "babel-plugin-lodash": "^3.3.4",
+        "babel-plugin-remove-graphql-queries": "^5.9.0",
+        "babel-preset-gatsby": "^3.9.0",
         "better-opn": "^2.1.1",
         "bluebird": "^3.7.2",
-        "body-parser": "1.20.3",
-        "browserslist": "^4.21.9",
+        "browserslist": "^4.21.4",
         "cache-manager": "^2.11.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
         "common-tags": "^1.8.2",
         "compression": "^1.7.4",
         "cookie": "^0.5.0",
-        "core-js": "^3.31.0",
+        "core-js": "^3.22.3",
         "cors": "^2.8.5",
         "css-loader": "^5.2.7",
         "css-minimizer-webpack-plugin": "^2.0.0",
         "css.escape": "^1.5.1",
-        "date-fns": "^2.30.0",
+        "date-fns": "^2.29.3",
         "debug": "^4.3.4",
-        "deepmerge": "^4.3.1",
+        "deepmerge": "^4.3.0",
         "detect-port": "^1.5.1",
         "devcert": "^1.2.2",
         "dotenv": "^8.6.0",
-        "enhanced-resolve": "^5.15.0",
+        "enhanced-resolve": "^5.12.0",
         "error-stack-parser": "^2.1.4",
         "eslint": "^7.32.0",
         "eslint-config-react-app": "^6.0.0",
         "eslint-plugin-flowtype": "^5.10.0",
         "eslint-plugin-import": "^2.27.5",
-        "eslint-plugin-jsx-a11y": "^6.8.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-webpack-plugin": "^2.7.0",
@@ -35008,36 +34879,36 @@
         "file-loader": "^6.2.0",
         "find-cache-dir": "^3.3.2",
         "fs-exists-cached": "1.0.0",
-        "fs-extra": "^11.2.0",
-        "gatsby-cli": "^5.14.0",
-        "gatsby-core-utils": "^4.14.0",
-        "gatsby-graphiql-explorer": "^3.14.0",
-        "gatsby-legacy-polyfills": "^3.14.0",
-        "gatsby-link": "^5.14.1",
-        "gatsby-page-utils": "^3.14.0",
-        "gatsby-parcel-config": "1.14.0",
-        "gatsby-plugin-page-creator": "^5.14.0",
-        "gatsby-plugin-typescript": "^5.14.0",
-        "gatsby-plugin-utils": "^4.14.0",
-        "gatsby-react-router-scroll": "^6.14.0",
-        "gatsby-script": "^2.14.0",
-        "gatsby-sharp": "^1.14.0",
-        "gatsby-worker": "^2.14.0",
+        "fs-extra": "^11.1.1",
+        "gatsby-cli": "^5.9.0",
+        "gatsby-core-utils": "^4.9.0",
+        "gatsby-graphiql-explorer": "^3.9.0",
+        "gatsby-legacy-polyfills": "^3.9.0",
+        "gatsby-link": "^5.9.0",
+        "gatsby-page-utils": "^3.9.0",
+        "gatsby-parcel-config": "1.9.0",
+        "gatsby-plugin-page-creator": "^5.9.0",
+        "gatsby-plugin-typescript": "^5.9.0",
+        "gatsby-plugin-utils": "^4.9.0",
+        "gatsby-react-router-scroll": "^6.9.0",
+        "gatsby-script": "^2.9.0",
+        "gatsby-sharp": "^1.9.0",
+        "gatsby-telemetry": "^4.9.0",
+        "gatsby-worker": "^2.9.0",
         "glob": "^7.2.3",
         "globby": "^11.1.0",
         "got": "^11.8.6",
-        "graphql": "^16.7.1",
+        "graphql": "^16.6.0",
         "graphql-compose": "^9.0.10",
-        "graphql-http": "^1.19.0",
+        "graphql-http": "^1.13.0",
         "graphql-tag": "^2.12.6",
         "hasha": "^5.2.2",
         "invariant": "^2.2.4",
         "is-relative": "^1.0.0",
         "is-relative-url": "^3.0.0",
-        "joi": "^17.9.2",
+        "joi": "^17.7.0",
         "json-loader": "^0.5.7",
         "latest-version": "^7.0.0",
-        "linkfs": "^2.1.0",
         "lmdb": "2.5.3",
         "lodash": "^4.17.21",
         "meant": "^1.0.3",
@@ -35048,17 +34919,16 @@
         "mitt": "^1.2.0",
         "moment": "^2.29.4",
         "multer": "^1.4.5-lts.1",
-        "node-fetch": "^2.6.11",
+        "node-fetch": "^2.6.8",
         "node-html-parser": "^5.4.2",
         "normalize-path": "^3.0.0",
         "null-loader": "^4.0.1",
         "opentracing": "^0.14.7",
         "p-defer": "^3.0.0",
         "parseurl": "^1.3.3",
-        "path-to-regexp": "0.1.10",
         "physical-cpu-count": "^2.0.0",
         "platform": "^1.3.6",
-        "postcss": "^8.4.24",
+        "postcss": "^8.4.21",
         "postcss-flexbugs-fixes": "^5.0.2",
         "postcss-loader": "^5.3.0",
         "prompts": "^2.4.2",
@@ -35071,29 +34941,28 @@
         "redux": "4.2.1",
         "redux-thunk": "^2.4.2",
         "resolve-from": "^5.0.0",
-        "semver": "^7.5.3",
+        "semver": "^7.3.8",
         "shallow-compare": "^1.2.2",
         "signal-exit": "^3.0.7",
-        "slugify": "^1.6.6",
-        "socket.io": "4.7.1",
-        "socket.io-client": "4.7.1",
+        "slugify": "^1.6.5",
+        "socket.io": "4.5.4",
+        "socket.io-client": "4.5.4",
         "stack-trace": "^0.0.10",
         "string-similarity": "^1.2.2",
         "strip-ansi": "^6.0.1",
         "style-loader": "^2.0.0",
-        "style-to-object": "^0.4.1",
-        "terser-webpack-plugin": "^5.3.9",
+        "terser-webpack-plugin": "^5.3.6",
         "tmp": "^0.2.1",
         "true-case-path": "^2.2.1",
         "type-of": "^2.0.1",
         "url-loader": "^4.1.1",
         "uuid": "^8.3.2",
-        "webpack": "^5.88.1",
-        "webpack-dev-middleware": "^5.3.4",
-        "webpack-merge": "^5.9.0",
-        "webpack-stats-plugin": "^1.1.3",
+        "webpack": "^5.75.0",
+        "webpack-dev-middleware": "^4.3.0",
+        "webpack-merge": "^5.8.0",
+        "webpack-stats-plugin": "^1.1.1",
         "webpack-virtual-modules": "^0.5.0",
-        "xstate": "^4.38.0",
+        "xstate": "^4.35.3",
         "yaml-loader": "^0.8.0"
       },
       "dependencies": {
@@ -35116,43 +34985,6 @@
           "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
           "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
           "dev": true
-        },
-        "body-parser": {
-          "version": "1.20.3",
-          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-          "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
-          "dev": true,
-          "requires": {
-            "bytes": "3.1.2",
-            "content-type": "~1.0.5",
-            "debug": "2.6.9",
-            "depd": "2.0.0",
-            "destroy": "1.2.0",
-            "http-errors": "2.0.0",
-            "iconv-lite": "0.4.24",
-            "on-finished": "2.4.1",
-            "qs": "6.13.0",
-            "raw-body": "2.5.2",
-            "type-is": "~1.6.18",
-            "unpipe": "1.0.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-              "dev": true
-            }
-          }
         },
         "cacheable-lookup": {
           "version": "5.0.4",
@@ -35219,29 +35051,17 @@
             "responselike": "^2.0.0"
           }
         },
+        "mime": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+          "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+          "dev": true
+        },
         "ms": {
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
-        },
-        "path-to-regexp": {
-          "version": "0.1.10",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-          "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
-          "dev": true
-        },
-        "raw-body": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-          "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-          "dev": true,
-          "requires": {
-            "bytes": "3.1.2",
-            "http-errors": "2.0.0",
-            "iconv-lite": "0.4.24",
-            "unpipe": "1.0.0"
-          }
         },
         "strip-ansi": {
           "version": "6.0.1",
@@ -35576,12 +35396,12 @@
       }
     },
     "gatsby-parcel-config": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/gatsby-parcel-config/-/gatsby-parcel-config-1.14.0.tgz",
-      "integrity": "sha512-S7RQOo1O5wzHxHB1AHh4xKbg8Jj76VPbSMfVsVVapL2Ht7p1zxrZ7p2pOX3pr5WJnfacREOQwLhlk8rk8TDbGw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/gatsby-parcel-config/-/gatsby-parcel-config-1.9.0.tgz",
+      "integrity": "sha512-5wclOXzeI6HmH5iEYvqzLnt/kc0cnqlIObRmQE2zpV0xs9YTPXAH7GdnaheYKN8kibF1EWuBKJF79dv99/nGHg==",
       "dev": true,
       "requires": {
-        "@gatsbyjs/parcel-namer-relative-to-cwd": "2.14.0",
+        "@gatsbyjs/parcel-namer-relative-to-cwd": "^2.9.0",
         "@parcel/bundler-default": "2.8.3",
         "@parcel/compressor-raw": "2.8.3",
         "@parcel/namer-default": "2.8.3",
@@ -35717,6 +35537,12 @@
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
           }
+        },
+        "mime": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+          "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+          "dev": true
         }
       }
     },
@@ -35743,6 +35569,32 @@
       "dev": true,
       "requires": {
         "sharp": "^0.32.6"
+      }
+    },
+    "gatsby-telemetry": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-4.14.0.tgz",
+      "integrity": "sha512-OvhbU3NxWYzmIdU2JX7xTCum5bm8S5AiZ3Z2Vl2U7GsQxx1BAU543yrHsRvcFqkX6diB+OXdEJUPaQyXmywMiA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.18.6",
+        "@babel/runtime": "^7.20.13",
+        "fs-extra": "^11.2.0",
+        "gatsby-core-utils": "^4.14.0",
+        "git-up": "^7.0.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "11.3.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+          "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        }
       }
     },
     "gatsby-worker": {
@@ -35894,6 +35746,16 @@
         "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6"
+      }
+    },
+    "git-up": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/git-up/-/git-up-7.0.0.tgz",
+      "integrity": "sha512-ONdIrbBCFusq1Oy0sC71F5azx8bVkvtZtMJAsv+a6lz5YAmbNnLD6HAB4gptHZVLPR8S2/kVN6Gab7lryq5+lQ==",
+      "dev": true,
+      "requires": {
+        "is-ssh": "^1.4.0",
+        "parse-url": "^8.1.0"
       }
     },
     "github-from-package": {
@@ -36122,9 +35984,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "16.10.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.10.0.tgz",
-      "integrity": "sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==",
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
       "dev": true
     },
     "graphql-compose": {
@@ -36511,12 +36373,6 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
-    },
-    "inline-style-parser": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
-      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==",
-      "dev": true
     },
     "inquirer": {
       "version": "7.3.3",
@@ -37005,6 +36861,15 @@
       "dev": true,
       "requires": {
         "call-bound": "^1.0.3"
+      }
+    },
+    "is-ssh": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.0.tgz",
+      "integrity": "sha512-x7+VxdxOdlV3CYpjvRLBv5Lo9OJerlYanjwFrPR9fuGPjCiNiCzFgAWpiLAohSbsnH4ZAys3SBh+hq5rJosxUQ==",
+      "dev": true,
+      "requires": {
+        "protocols": "^2.0.1"
       }
     },
     "is-stream": {
@@ -37836,6 +37701,23 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dev": true,
+      "requires": {
+        "p-defer": "^1.0.0"
+      },
+      "dependencies": {
+        "p-defer": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+          "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
+          "dev": true
+        }
+      }
+    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -37869,6 +37751,24 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "mem": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
+      "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
+      "dev": true,
+      "requires": {
+        "map-age-cleaner": "^0.1.3",
+        "mimic-fn": "^3.1.0"
+      },
+      "dependencies": {
+        "mimic-fn": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+          "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
+          "dev": true
+        }
+      }
     },
     "memfs": {
       "version": "3.4.7",
@@ -37975,11 +37875,6 @@
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       }
-    },
-    "mime": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="
     },
     "mime-db": {
       "version": "1.52.0",
@@ -38222,9 +38117,9 @@
       "optional": true
     },
     "nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
       "dev": true
     },
     "napi-build-utils": {
@@ -38941,6 +38836,24 @@
       "integrity": "sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==",
       "dev": true
     },
+    "parse-path": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.0.0.tgz",
+      "integrity": "sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==",
+      "dev": true,
+      "requires": {
+        "protocols": "^2.0.0"
+      }
+    },
+    "parse-url": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-8.1.0.tgz",
+      "integrity": "sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==",
+      "dev": true,
+      "requires": {
+        "parse-path": "^7.0.0"
+      }
+    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -39229,14 +39142,14 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.4.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.23.tgz",
+      "integrity": "sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==",
       "dev": true,
       "requires": {
-        "nanoid": "^3.3.8",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
       }
     },
     "postcss-calc": {
@@ -39724,6 +39637,12 @@
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true
     },
+    "protocols": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz",
+      "integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==",
+      "dev": true
+    },
     "proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -39733,12 +39652,6 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       }
-    },
-    "proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
     },
     "ps-list": {
       "version": "8.1.0",
@@ -39768,11 +39681,11 @@
       "dev": true
     },
     "qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
       "requires": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.0.4"
       }
     },
     "query-string": {
@@ -40993,9 +40906,9 @@
       }
     },
     "slugify": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
-      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
+      "integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ==",
       "dev": true
     },
     "snake-case": {
@@ -41009,18 +40922,17 @@
       }
     },
     "socket.io": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.1.tgz",
-      "integrity": "sha512-W+utHys2w//dhFjy7iQQu9sGd3eokCjGbl2r59tyLqNiJJBdIebn3GAKEXBr3osqHTObJi2die/25bCx2zsaaw==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.4.tgz",
+      "integrity": "sha512-m3GC94iK9MfIEeIBfbhJs5BqFibMtkRk8ZpKwG2QwxV0m/eEhPIV4ara6XCF1LWNAus7z58RodiZlAH71U3EhQ==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
-        "cors": "~2.8.5",
         "debug": "~4.3.2",
-        "engine.io": "~6.5.0",
-        "socket.io-adapter": "~2.5.2",
-        "socket.io-parser": "~4.2.4"
+        "engine.io": "~6.2.1",
+        "socket.io-adapter": "~2.4.0",
+        "socket.io-parser": "~4.2.1"
       },
       "dependencies": {
         "debug": {
@@ -41035,42 +40947,21 @@
       }
     },
     "socket.io-adapter": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
-      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
-      "dev": true,
-      "requires": {
-        "debug": "~4.3.4",
-        "ws": "~8.17.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-          "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.3"
-          }
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-          "dev": true
-        }
-      }
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz",
+      "integrity": "sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==",
+      "dev": true
     },
     "socket.io-client": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.1.tgz",
-      "integrity": "sha512-Qk3Xj8ekbnzKu3faejo4wk2MzXA029XppiXtTF/PkbTg+fcwaTw1PlDrTrrrU4mKoYC4dvlApOnSeyLCKwek2w==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.5.4.tgz",
+      "integrity": "sha512-ZpKteoA06RzkD32IbqILZ+Cnst4xewU7ZYK12aS1mzHftFFjpoMz69IuhP/nL25pJfao/amoPI527KnuhFm01g==",
       "dev": true,
       "requires": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.2",
-        "engine.io-client": "~6.5.1",
-        "socket.io-parser": "~4.2.4"
+        "engine.io-client": "~6.2.3",
+        "socket.io-parser": "~4.2.1"
       },
       "dependencies": {
         "debug": {
@@ -41124,9 +41015,9 @@
       "dev": true
     },
     "source-map-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true
     },
     "source-map-support": {
@@ -41469,15 +41360,6 @@
       "requires": {
         "loader-utils": "^2.0.0",
         "schema-utils": "^3.0.0"
-      }
-    },
-    "style-to-object": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.4.tgz",
-      "integrity": "sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==",
-      "dev": true,
-      "requires": {
-        "inline-style-parser": "0.1.1"
       }
     },
     "stylehacks": {
@@ -42162,6 +42044,11 @@
         "pathe": "^1.1.1"
       },
       "dependencies": {
+        "mime": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+          "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="
+        },
         "pathe": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.1.tgz",
@@ -42500,67 +42387,34 @@
       }
     },
     "webpack-dev-middleware": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
-      "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-4.3.0.tgz",
+      "integrity": "sha512-PjwyVY95/bhBh6VUqt6z4THplYcsvQ8YNNBTBM873xLVmw8FLeALn0qurHbs9EmcfhzQis/eoqypSnZeuUz26w==",
       "dev": true,
       "requires": {
-        "colorette": "^2.0.10",
-        "memfs": "^3.4.3",
-        "mime-types": "^2.1.31",
+        "colorette": "^1.2.2",
+        "mem": "^8.1.1",
+        "memfs": "^3.2.2",
+        "mime-types": "^2.1.30",
         "range-parser": "^1.2.1",
-        "schema-utils": "^4.0.0"
+        "schema-utils": "^3.0.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "8.17.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-          "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.3",
-            "fast-uri": "^3.0.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2"
-          }
-        },
-        "ajv-keywords": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-          "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.3"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+        "colorette": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+          "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
           "dev": true
-        },
-        "schema-utils": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
-          "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.9",
-            "ajv": "^8.9.0",
-            "ajv-formats": "^2.1.1",
-            "ajv-keywords": "^5.1.0"
-          }
         }
       }
     },
     "webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
+      "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
       "dev": true,
       "requires": {
         "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
         "wildcard": "^2.0.0"
       }
     },
@@ -42876,9 +42730,9 @@
       }
     },
     "ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
       "dev": true
     },
     "xdg-basedir": {

--- a/plugin/src/helpers/cache.ts
+++ b/plugin/src/helpers/cache.ts
@@ -5,7 +5,7 @@ import type { NetlifyPluginOptions } from '@netlify/build'
 
 import { getGatsbyRoot } from './config'
 
-function getCacheDirs(publish) {
+export function getCacheDirs(publish) {
   return [publish, normalizedCacheDir(publish)]
 }
 

--- a/plugin/src/helpers/config.ts
+++ b/plugin/src/helpers/config.ts
@@ -409,18 +409,4 @@ export function shouldSkip(publishDir: string): boolean {
 
   return shouldSkipResult
 }
-
-export function checkNetlifyImageCdn({
-  netlifyConfig,
-}: {
-  netlifyConfig: NetlifyConfig
-}): void {
-  /* eslint-disable no-param-reassign */
-  const { NETLIFY_IMAGE_CDN } = netlifyConfig.build.environment
-
-  if (NETLIFY_IMAGE_CDN === 'true') {
-    netlifyConfig.build.environment.GATSBY_CLOUD_IMAGE_CDN = 'true'
-  }
-  /* eslint-enable no-param-reassign */
-}
 /* eslint-enable max-lines */

--- a/plugin/src/helpers/functions.ts
+++ b/plugin/src/helpers/functions.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { NetlifyConfig, NetlifyPluginConstants } from '@netlify/build'
 import { copy, copyFile, ensureDir, existsSync, rm, writeFile } from 'fs-extra'
 import { resolve, join, relative } from 'pathe'
@@ -5,6 +6,11 @@ import { resolve, join, relative } from 'pathe'
 import { makeApiHandler, makeHandler } from '../templates/handlers'
 
 import { getGatsbyRoot } from './config'
+import {
+  ImageCdnImplementation,
+  ImageCdnUrlSyntax,
+  type PrepareImageCdnResult,
+} from './image_cdn'
 
 export type FunctionList = Array<'API' | 'SSR' | 'DSG'>
 
@@ -37,15 +43,19 @@ export const writeFunctions = async ({
   constants,
   netlifyConfig,
   neededFunctions,
+  prepareImageCdnResult,
 }: {
   constants: NetlifyPluginConstants
   netlifyConfig: NetlifyConfig
   neededFunctions: FunctionList
+  prepareImageCdnResult?: PrepareImageCdnResult
 }): Promise<void> => {
   const { PUBLISH_DIR, INTERNAL_FUNCTIONS_SRC } = constants
   const siteRoot = getGatsbyRoot(PUBLISH_DIR)
   const functionDir = resolve(INTERNAL_FUNCTIONS_SRC, '__api')
   const appDir = relative(functionDir, siteRoot)
+
+  await ensureDir(INTERNAL_FUNCTIONS_SRC)
 
   if (neededFunctions.includes('SSR')) {
     await writeFunction({
@@ -65,97 +75,158 @@ export const writeFunctions = async ({
     })
   }
 
-  await setupImageCdn({ constants, netlifyConfig })
+  if (
+    prepareImageCdnResult &&
+    prepareImageCdnResult.imageCDNImplementation !== 'NONE'
+  ) {
+    await setupImageCdn({ constants, netlifyConfig, prepareImageCdnResult })
+  }
 
   if (neededFunctions.includes('API')) {
     await writeApiFunction({ appDir, functionDir })
   }
 }
 
+// eslint-disable-next-line max-lines-per-function, complexity
 export const setupImageCdn = async ({
   constants,
   netlifyConfig,
+  prepareImageCdnResult,
 }: {
   constants: NetlifyPluginConstants
   netlifyConfig: NetlifyConfig
+  prepareImageCdnResult: PrepareImageCdnResult
 }) => {
-  const { GATSBY_CLOUD_IMAGE_CDN, NETLIFY_IMAGE_CDN } =
-    netlifyConfig.build.environment
-
-  if (
-    NETLIFY_IMAGE_CDN !== `true` &&
-    GATSBY_CLOUD_IMAGE_CDN !== '1' &&
-    GATSBY_CLOUD_IMAGE_CDN !== 'true'
-  ) {
-    return
-  }
-
-  await ensureDir(constants.INTERNAL_FUNCTIONS_SRC)
-
-  await copyFile(
+  await ensureDir(join(constants.INTERNAL_FUNCTIONS_SRC, '_ipx'))
+  await copy(
     join(__dirname, '..', '..', 'src', 'templates', 'ipx.ts'),
-    join(constants.INTERNAL_FUNCTIONS_SRC, '_ipx.ts'),
+    join(constants.INTERNAL_FUNCTIONS_SRC, '_ipx', '_ipx.ts'),
+    { overwrite: true },
   )
 
-  if (NETLIFY_IMAGE_CDN === `true`) {
+  await writeFile(
+    join(constants.INTERNAL_FUNCTIONS_SRC, '_ipx', 'config.ts'),
+    `exports.config = ${JSON.stringify(prepareImageCdnResult.imageCDNConfig)}`,
+  )
+
+  if (
+    prepareImageCdnResult.imageCDNImplementation ===
+    ImageCdnImplementation.NETLIFY_IMAGE_CDN
+  ) {
     await copyFile(
       join(__dirname, '..', '..', 'src', 'templates', 'image.ts'),
       join(constants.INTERNAL_FUNCTIONS_SRC, '__image.ts'),
     )
 
     netlifyConfig.redirects.push(
-      {
-        from: '/_gatsby/image/:unused/:unused2/:filename',
-        // eslint-disable-next-line id-length
-        query: { u: ':url', a: ':args', cd: ':cd' },
-        to: '/.netlify/functions/__image/image_query_compat?url=:url&args=:args&cd=:cd',
-        status: 301,
-        force: true,
-      },
-      {
-        from: '/_gatsby/image/*',
-        to: '/.netlify/functions/__image',
-        status: 200,
-        force: true,
-      },
+      ...[
+        // QUERY_WITH_ENCRYPTED_URL is forcefully disable when using Netlify Image CDN
+        // so we don't need to handle it here
+        prepareImageCdnResult.imageCDNConfig.enabledUrlPatterns.includes(
+          ImageCdnUrlSyntax.QUERY,
+        )
+          ? {
+              from: '/_gatsby/image/:unused/:unused2/:filename',
+              // eslint-disable-next-line id-length
+              query: { u: ':url', a: ':args', cd: ':cd' },
+              to: '/.netlify/functions/__image/image_query_compat?url=:url&args=:args&cd=:cd',
+              status: 301,
+              force: true,
+            }
+          : undefined,
+        prepareImageCdnResult.imageCDNConfig.enabledUrlPatterns.includes(
+          ImageCdnUrlSyntax.BASE64,
+        )
+          ? {
+              from: '/_gatsby/image/*',
+              to: '/.netlify/functions/__image',
+              status: 200,
+              force: true,
+            }
+          : undefined,
+      ].filter(Boolean),
     )
   } else if (
-    GATSBY_CLOUD_IMAGE_CDN === '1' ||
-    GATSBY_CLOUD_IMAGE_CDN === 'true'
+    prepareImageCdnResult.imageCDNImplementation === ImageCdnImplementation.IPX
   ) {
     netlifyConfig.redirects.push(
-      {
-        from: `/_gatsby/image/:unused/:unused2/:filename`,
-        // eslint-disable-next-line id-length
-        query: { u: ':url', a: ':args' },
-        to: `/.netlify/builders/_ipx/image_query_compat/:args/:url/:filename`,
-        status: 301,
-        force: true,
-      },
-      {
-        from: '/_gatsby/image/*',
-        to: '/.netlify/builders/_ipx',
-        status: 200,
-        force: true,
-      },
+      // eslint-disable-next-line no-sparse-arrays
+      ...[
+        prepareImageCdnResult.imageCDNConfig.enabledUrlPatterns.includes(
+          ImageCdnUrlSyntax.QUERY_WITH_ENCRYPTED_URL,
+        )
+          ? {
+              from: `/_gatsby/image/:unused/:unused2/:filename`,
+              // eslint-disable-next-line id-length
+              query: { eu: ':encrypted_url', a: ':args' },
+              to: `/.netlify/builders/_ipx/image_query_compat_eu/:args/:encrypted_url/:filename`,
+              status: 301,
+              force: true,
+            }
+          : undefined,
+        prepareImageCdnResult.imageCDNConfig.enabledUrlPatterns.includes(
+          ImageCdnUrlSyntax.QUERY,
+        )
+          ? {
+              from: `/_gatsby/image/:unused/:unused2/:filename`,
+              // eslint-disable-next-line id-length
+              query: { u: ':url', a: ':args' },
+              to: `/.netlify/builders/_ipx/image_query_compat/:args/:url/:filename`,
+              status: 301,
+              force: true,
+            }
+          : undefined,
+        prepareImageCdnResult.imageCDNConfig.enabledUrlPatterns.includes(
+          ImageCdnUrlSyntax.BASE64,
+        )
+          ? {
+              from: '/_gatsby/image/*',
+              to: '/.netlify/builders/_ipx',
+              status: 200,
+              force: true,
+            }
+          : undefined,
+        ,
+      ].filter(Boolean),
     )
   }
 
   netlifyConfig.redirects.push(
-    {
-      from: `/_gatsby/file/:unused/:filename`,
-      // eslint-disable-next-line id-length
-      query: { u: ':url' },
-      to: `/.netlify/functions/_ipx/file_query_compat/:url/:filename`,
-      status: 301,
-      force: true,
-    },
-    {
-      from: '/_gatsby/file/*',
-      to: '/.netlify/functions/_ipx',
-      status: 200,
-      force: true,
-    },
+    ...[
+      prepareImageCdnResult.imageCDNConfig.enabledUrlPatterns.includes(
+        ImageCdnUrlSyntax.QUERY_WITH_ENCRYPTED_URL,
+      )
+        ? {
+            from: `/_gatsby/file/:unused/:filename`,
+            query: { eu: ':encrypted_url' },
+            to: `/.netlify/functions/_ipx/file_query_compat_eu/:encrypted_url/:filename`,
+            status: 301,
+            force: true,
+          }
+        : undefined,
+      prepareImageCdnResult.imageCDNConfig.enabledUrlPatterns.includes(
+        ImageCdnUrlSyntax.QUERY,
+      )
+        ? {
+            from: `/_gatsby/file/:unused/:filename`,
+            // eslint-disable-next-line id-length
+            query: { u: ':url' },
+            to: `/.netlify/functions/_ipx/file_query_compat/:url/:filename`,
+            status: 301,
+            force: true,
+          }
+        : undefined,
+      prepareImageCdnResult.imageCDNConfig.enabledUrlPatterns.includes(
+        ImageCdnUrlSyntax.BASE64,
+      )
+        ? {
+            from: '/_gatsby/file/*',
+            to: '/.netlify/functions/_ipx',
+            status: 200,
+            force: true,
+          }
+        : undefined,
+    ].filter(Boolean),
   )
 }
 
@@ -169,3 +240,4 @@ export const deleteFunctions = async ({
     }
   }
 }
+/* eslint-enable max-lines */

--- a/plugin/src/helpers/image_cdn.ts
+++ b/plugin/src/helpers/image_cdn.ts
@@ -1,0 +1,293 @@
+/* eslint-disable max-lines */
+import crypto from 'crypto'
+import { createRequire } from 'module'
+import { join } from 'path'
+
+import { NetlifyConfig } from '@netlify/build'
+import { readJSON, existsSync, writeJSON, remove } from 'fs-extra'
+
+import type {
+  EncryptionConfig,
+  IMAGE_CDN_URL_PATTERN,
+  ImageCDNConfig,
+} from '../templates/ipx'
+
+import { getCacheDirs, normalizedCacheDir } from './cache'
+import { getGatsbyRoot } from './config'
+
+// eslint-disable-next-line no-shadow
+export enum ImageCdnImplementation {
+  NETLIFY_IMAGE_CDN = 'NETLIFY_IMAGE_CDN',
+  IPX = 'IPX',
+  NONE = 'NONE',
+}
+
+function selectImageCdnImplementation({
+  netlifyConfig,
+}: {
+  netlifyConfig: NetlifyConfig
+}) {
+  /* eslint-disable no-param-reassign */
+  const { NETLIFY_IMAGE_CDN, GATSBY_CLOUD_IMAGE_CDN } =
+    netlifyConfig.build.environment
+
+  const imageCDNEnabled =
+    GATSBY_CLOUD_IMAGE_CDN === '1' || GATSBY_CLOUD_IMAGE_CDN === 'true'
+
+  if (NETLIFY_IMAGE_CDN === 'true') {
+    if (!imageCDNEnabled) {
+      // we do need to ensure GATSBY_CLOUD_IMAGE_CDN env var for Gatsby to not
+      // transform images at build time
+      netlifyConfig.build.environment.GATSBY_CLOUD_IMAGE_CDN = 'true'
+    }
+    return ImageCdnImplementation.NETLIFY_IMAGE_CDN
+  }
+
+  if (imageCDNEnabled) {
+    return ImageCdnImplementation.IPX
+  }
+
+  return ImageCdnImplementation.NONE
+  /* eslint-enable no-param-reassign */
+}
+
+export const ImageCdnUrlSyntax: Record<
+  IMAGE_CDN_URL_PATTERN,
+  IMAGE_CDN_URL_PATTERN
+> = {
+  QUERY_WITH_ENCRYPTED_URL: 'QUERY_WITH_ENCRYPTED_URL',
+  QUERY: 'QUERY',
+  BASE64: 'BASE64',
+  NONE: 'NONE',
+}
+
+function getGatsbyPluginUtilsSyntax(contextRequire: NodeRequire) {
+  try {
+    const urlGeneratorExports = contextRequire(
+      'gatsby-plugin-utils/polyfill-remote-file/utils/url-generator',
+    )
+    if (urlGeneratorExports.ImageCDNUrlKeys) {
+      return urlGeneratorExports.ImageCDNUrlKeys.ENCRYPTED_URL
+        ? ImageCdnUrlSyntax.QUERY_WITH_ENCRYPTED_URL
+        : ImageCdnUrlSyntax.QUERY
+    }
+
+    return ImageCdnUrlSyntax.BASE64
+  } catch {}
+
+  return ImageCdnUrlSyntax.NONE
+}
+
+// list of known packages using Gatsby Image CDN that don't use their dedicated image transformation service
+// compiled through manual inspection of https://github.com/search?q=addRemoteFilePolyfillInterface&type=code
+const gatsbySourcePluginsUsingImageCdn = [
+  // gatsby owned
+  'gatsby-source-drupal',
+  'gatsby-source-wordpress',
+  // 3rd party
+  'gatsby-source-sanity',
+  'gatsby-plugin-remote-images',
+  'gatsby-source-youtube-oembed',
+  'gatsby-source-airtable-next',
+  'gatsby-source-directus',
+]
+
+export type PrepareImageCdnResult = {
+  postBuildCallback: () => Promise<void>
+  imageCDNConfig: ImageCDNConfig
+  imageCDNImplementation: ImageCdnImplementation
+}
+
+function detectImageCdnUrlPatterns({
+  publish,
+  imageCDNImplementation,
+}: {
+  publish: string
+  imageCDNImplementation: ImageCdnImplementation
+}) {
+  const detectedSyntaxes = new Set<IMAGE_CDN_URL_PATTERN>()
+  const siteRequire = createRequire(`${getGatsbyRoot(publish)}/:internal:`)
+
+  try {
+    detectedSyntaxes.add(getGatsbyPluginUtilsSyntax(siteRequire))
+  } catch {}
+
+  for (const packageUsingGatsbyImageCdn of gatsbySourcePluginsUsingImageCdn) {
+    try {
+      const packageRequire = createRequire(
+        siteRequire.resolve(packageUsingGatsbyImageCdn),
+      )
+      detectedSyntaxes.add(getGatsbyPluginUtilsSyntax(packageRequire))
+    } catch {}
+  }
+
+  // we only have NONE, because we need to return something from detection helper, so let's remove it from the list
+  detectedSyntaxes.delete(ImageCdnUrlSyntax.NONE)
+  if (detectedSyntaxes.size === 0) {
+    // automatic detection is not ideal, so it might not find gatsby-plugin-utils even it it is actually used
+    // in this case we fall back to the most recent and safe one
+    detectedSyntaxes.add(ImageCdnUrlSyntax.QUERY_WITH_ENCRYPTED_URL)
+  }
+
+  if (
+    imageCDNImplementation === ImageCdnImplementation.NETLIFY_IMAGE_CDN &&
+    detectedSyntaxes.has(ImageCdnUrlSyntax.QUERY_WITH_ENCRYPTED_URL)
+  ) {
+    // Netlify Image CDN can't handle encrypted URLs, but it uses allowlist instead, so we replace QUERY_WITH_ENCRYPTED_URL with QUERY
+    // Remote urls Allow list is required form Netlify Image CDN to work, so this should ensure no unauthorized remote urls can be
+    // used successfully
+    detectedSyntaxes.delete(ImageCdnUrlSyntax.QUERY_WITH_ENCRYPTED_URL)
+    detectedSyntaxes.add(ImageCdnUrlSyntax.QUERY)
+  }
+
+  return [...detectedSyntaxes]
+}
+
+const IMAGE_CDN_ENCRYPTION_SECRET_KEY_LENGTH = 32
+const IMAGE_CDN_ENCRYPTION_IV_LENGTH = 16
+
+function setupImageCdnUrlEncryption({
+  previousImageCdnConfig,
+  netlifyConfig,
+  imageCDNImplementation,
+  enabledUrlPatterns,
+}: {
+  previousImageCdnConfig: ImageCDNConfig | undefined
+  netlifyConfig: NetlifyConfig
+  imageCDNImplementation: ImageCdnImplementation
+  enabledUrlPatterns: IMAGE_CDN_URL_PATTERN[]
+}): EncryptionConfig | undefined {
+  const shouldUseUrlEncryption =
+    imageCDNImplementation === ImageCdnImplementation.IPX &&
+    enabledUrlPatterns.includes(ImageCdnUrlSyntax.QUERY_WITH_ENCRYPTED_URL)
+
+  if (!shouldUseUrlEncryption) {
+    return
+  }
+
+  // if environment variables are already set - use them
+  if (
+    netlifyConfig.build.environment.IMAGE_CDN_ENCRYPTION_SECRET_KEY &&
+    netlifyConfig.build.environment.IMAGE_CDN_ENCRYPTION_IV
+  ) {
+    return {
+      IMAGE_CDN_ENCRYPTION_SECRET_KEY:
+        netlifyConfig.build.environment.IMAGE_CDN_ENCRYPTION_SECRET_KEY,
+      IMAGE_CDN_ENCRYPTION_IV:
+        netlifyConfig.build.environment.IMAGE_CDN_ENCRYPTION_IV,
+    }
+  }
+
+  let encryptionConfig = previousImageCdnConfig?.encryptionConfig
+
+  if (!encryptionConfig) {
+    // if we don't yet have encryption config, generate new one
+    encryptionConfig = {
+      IMAGE_CDN_ENCRYPTION_SECRET_KEY: crypto
+        .randomBytes(IMAGE_CDN_ENCRYPTION_SECRET_KEY_LENGTH)
+        .toString(`hex`),
+      IMAGE_CDN_ENCRYPTION_IV: crypto
+        .randomBytes(IMAGE_CDN_ENCRYPTION_IV_LENGTH)
+        .toString(`hex`),
+    }
+  }
+
+  // eslint-disable-next-line no-param-reassign
+  netlifyConfig.build.environment.IMAGE_CDN_ENCRYPTION_SECRET_KEY =
+    encryptionConfig.IMAGE_CDN_ENCRYPTION_SECRET_KEY
+  // eslint-disable-next-line no-param-reassign
+  netlifyConfig.build.environment.IMAGE_CDN_ENCRYPTION_IV =
+    encryptionConfig.IMAGE_CDN_ENCRYPTION_IV
+
+  return encryptionConfig
+}
+
+// eslint-disable-next-line max-statements
+export async function prepareImageCdn({
+  publish,
+  netlifyConfig,
+}: {
+  publish: string
+  netlifyConfig: NetlifyConfig
+}): Promise<PrepareImageCdnResult> {
+  const cacheDir = normalizedCacheDir(publish)
+  // private location that is cached between builds, but not exposed to public
+  const imageCdnConfigFile = join(cacheDir, 'imageCdnEncryptionConfig.json')
+
+  let previousImageCdnConfig: ImageCDNConfig | undefined
+
+  try {
+    previousImageCdnConfig = await readJSON(imageCdnConfigFile)
+  } catch {}
+
+  const imageCDNImplementation = await selectImageCdnImplementation({
+    netlifyConfig,
+  })
+
+  const enabledUrlPatterns = await detectImageCdnUrlPatterns({
+    publish,
+    imageCDNImplementation,
+  })
+
+  const encryptionConfig = await setupImageCdnUrlEncryption({
+    previousImageCdnConfig,
+    netlifyConfig,
+    imageCDNImplementation,
+    enabledUrlPatterns,
+  })
+
+  const allowedRemoteUrls =
+    // use defined remote images if user configured them
+    netlifyConfig.images?.remote_images ??
+    // if they are not configured and user
+    //  - is using Netlify Image CDN - we should use empty array to disallow any remote url
+    //  - is using IPX - we should not setup remote urls as IPX/Gatsby Cloud never required them and this would be breaking change
+    imageCDNImplementation === ImageCdnImplementation.NETLIFY_IMAGE_CDN
+      ? []
+      : undefined
+
+  const imageCDNConfig: ImageCDNConfig = {
+    enabledUrlPatterns,
+    encryptionConfig,
+    allowedRemoteUrls,
+  }
+
+  // some configuration change require to throw away previous build artifacts to prevent gatsby from reusing
+  // previous html/json files that would contain old urls that would not work with new configuration
+  // so we need to ensure fresh builds when at least one of the following changed since last build:
+  // - enabledUrlPatterns changed
+  // - encryption changed
+  const enabledUrlPatternsChanged =
+    JSON.stringify(previousImageCdnConfig?.enabledUrlPatterns) !==
+    JSON.stringify(imageCDNConfig.enabledUrlPatterns)
+  const encryptionConfigChanged =
+    JSON.stringify(previousImageCdnConfig?.encryptionConfig) !==
+    JSON.stringify(imageCDNConfig.encryptionConfig)
+
+  if (enabledUrlPatternsChanged || encryptionConfigChanged) {
+    const dirsToClean = getCacheDirs(publish).filter(existsSync)
+    if (dirsToClean.length !== 0) {
+      console.log(
+        `Image CDN configuration changed:${
+          enabledUrlPatternsChanged ? `\n - enabledUrlPatterns` : ''
+        }${
+          encryptionConfigChanged ? `\n - encryptionConfig` : ''
+        }\nCleaning previous build and building fresh.`,
+      )
+      for (const dirToClean of dirsToClean) {
+        await remove(dirToClean)
+      }
+    }
+  }
+
+  return {
+    imageCDNConfig,
+    imageCDNImplementation,
+    postBuildCallback: async () => {
+      // .cache directory might not exist yet, so to not mess with Gatsby itself
+      // we delay storing the config for future build until after the build
+      await writeJSON(imageCdnConfigFile, imageCDNConfig)
+    },
+  }
+}
+/* eslint-enable max-lines */

--- a/plugin/src/templates/ipx.ts
+++ b/plugin/src/templates/ipx.ts
@@ -1,7 +1,42 @@
 import { Buffer } from 'buffer'
+import crypto from 'crypto'
 
 import { Handler, HandlerResponse } from '@netlify/functions'
 import { createIPXHandler } from '@netlify/ipx'
+
+/**
+ * @type {import('./config').IpxWrapperConfig}
+ */
+import {
+  config as untypedRawConfig,
+  // @ts-expect-error This file is generated
+} from './config'
+
+export type EncryptionConfig = {
+  IMAGE_CDN_ENCRYPTION_SECRET_KEY: string
+  IMAGE_CDN_ENCRYPTION_IV: string
+}
+
+export type IMAGE_CDN_URL_PATTERN =
+  | 'QUERY_WITH_ENCRYPTED_URL'
+  | 'QUERY'
+  | 'BASE64'
+  | 'NONE'
+
+export type ImageCDNConfig = {
+  allowedRemoteUrls?: string[]
+  encryptionConfig?: EncryptionConfig
+  enabledUrlPatterns: IMAGE_CDN_URL_PATTERN[]
+}
+
+const rawConfig = untypedRawConfig as ImageCDNConfig
+
+const config = {
+  ...rawConfig,
+  remoteUrls: rawConfig.allowedRemoteUrls?.map(
+    (remoteUrl) => new RegExp(remoteUrl),
+  ),
+}
 
 type Event = Parameters<Handler>[0]
 
@@ -11,69 +46,115 @@ const ipxHandler = createIPXHandler({
   bypassDomainCheck: true,
 })
 
+function decryptUrl(url: string): string {
+  if (config.encryptionConfig) {
+    const key = Buffer.from(
+      config.encryptionConfig.IMAGE_CDN_ENCRYPTION_SECRET_KEY,
+      `hex`,
+    )
+    const iv = Buffer.from(
+      config.encryptionConfig.IMAGE_CDN_ENCRYPTION_IV,
+      `hex`,
+    )
+
+    const decipher = crypto.createDecipheriv(`aes-256-ctr`, key, iv)
+
+    const decrypted = decipher.update(Buffer.from(url, `hex`))
+    const clearText = Buffer.concat([decrypted, decipher.final()]).toString()
+    const [
+      // padding is delimited by a ":"
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      _randomPadding,
+      // urls also contain ":"
+      ...urlParts
+    ] = clearText.split(`:`)
+
+    const decodedUrl = urlParts.join(`:`)
+
+    return decodedUrl
+  }
+
+  throw new Error(`No encryption config found`)
+}
+
 const QUERY_PARAM_IMAGE_REDIRECT_URL =
-  /^\/\.netlify\/builders\/_ipx\/image_query_compat\/([^/]+?)\/([^/]+?)\/([^/]+?)\/?$/i
+  /^\/\.netlify\/builders\/_ipx\/image_query_compat(?<eu>_eu)?\/(?<args>[^/]+?)\/(?<url>[^/]+?)\/([^/]+?)\/?$/i
 const QUERY_PARAM_FILE_REDIRECT_URL =
-  /^\/\.netlify\/functions\/_ipx\/file_query_compat\/([^/]+?)\/([^/]+?)\/?$/i
+  /^\/\.netlify\/functions\/_ipx\/file_query_compat(?<eu>_eu)?\/(?<url>[^/]+?)\/([^/]+?)\/?$/i
 
 function matchRequestTypeAndArguments(event: Event):
   | {
       type: `file`
       url: string
       originalHost: string
+      urlPattern: IMAGE_CDN_URL_PATTERN
     }
   | {
       type: `image`
+      url: string
       event: Event
+      urlPattern: IMAGE_CDN_URL_PATTERN
     }
   | undefined {
   const { pathname, host } = new URL(event.rawUrl)
 
   const queryParamImageMatch = pathname.match(QUERY_PARAM_IMAGE_REDIRECT_URL)
-  if (queryParamImageMatch) {
-    const [, urlEncodedArgs, urlEncodedUrl] = queryParamImageMatch
-    const base64EncodedUrl = Buffer.from(
-      decodeURIComponent(urlEncodedUrl),
-      'utf8',
-    ).toString('base64')
+  if (queryParamImageMatch?.groups) {
+    const url = queryParamImageMatch.groups.eu
+      ? decryptUrl(queryParamImageMatch.groups.url)
+      : decodeURIComponent(queryParamImageMatch.groups.url)
+
+    const base64EncodedUrl = Buffer.from(url, 'utf8').toString('base64')
     const base64EncodedArgs = Buffer.from(
-      decodeURIComponent(urlEncodedArgs),
+      decodeURIComponent(queryParamImageMatch.groups.args),
       'utf8',
     ).toString('base64')
 
     return {
       type: `image`,
+      url,
       event: {
         ...event,
         path: `/_gatsby/image/${base64EncodedUrl}/${base64EncodedArgs}`,
       },
+      urlPattern: queryParamImageMatch.groups.eu
+        ? 'QUERY_WITH_ENCRYPTED_URL'
+        : 'QUERY',
     }
   }
 
   const queryParamFileMatch = pathname.match(QUERY_PARAM_FILE_REDIRECT_URL)
-  if (queryParamFileMatch) {
-    const [, encodedUrl] = queryParamFileMatch
-    const url = decodeURIComponent(encodedUrl)
+  if (queryParamFileMatch?.groups) {
+    const url = queryParamFileMatch.groups.eu
+      ? decryptUrl(queryParamFileMatch.groups.url)
+      : decodeURIComponent(queryParamFileMatch.groups.url)
 
     return {
       type: `file`,
       url,
       originalHost: host,
+      urlPattern: queryParamFileMatch.groups.eu
+        ? 'QUERY_WITH_ENCRYPTED_URL'
+        : 'QUERY',
     }
   }
 
   const [, , type, encodedUrl] = pathname.split('/')
+  const url = Buffer.from(encodedUrl, 'base64').toString('utf8')
   if (type === `file`) {
     return {
       type: `file`,
-      url: Buffer.from(encodedUrl, 'base64').toString('utf8'),
+      url,
       originalHost: host,
+      urlPattern: 'BASE64',
     }
   }
   if (type === `image`) {
     return {
       type: `image`,
+      url,
       event,
+      urlPattern: 'BASE64',
     }
   }
 
@@ -84,7 +165,27 @@ function matchRequestTypeAndArguments(event: Event):
 // eslint-disable-next-line require-await
 export const handler: Handler = async (event, ...rest) => {
   const requestTypeAndArgs = matchRequestTypeAndArguments(event)
+
   if (!requestTypeAndArgs) {
+    return {
+      statusCode: 400,
+      body: 'Invalid request',
+    }
+  }
+
+  if (!config.enabledUrlPatterns.includes(requestTypeAndArgs.urlPattern)) {
+    return {
+      statusCode: 400,
+      body: 'Invalid request',
+    }
+  }
+
+  if (
+    config.remoteUrls &&
+    !config.remoteUrls.some((remoteUrl) =>
+      remoteUrl.test(requestTypeAndArgs.url),
+    )
+  ) {
     return {
       statusCode: 400,
       body: 'Invalid request',
@@ -117,10 +218,12 @@ export const handler: Handler = async (event, ...rest) => {
       body: '',
     }
   } catch (error) {
-    console.error(error)
     return {
       statusCode: 400,
-      body: 'Invalid request',
+      body: JSON.stringify({
+        msg: `Redirecting to ${requestTypeAndArgs.url} failed`,
+        error,
+      }),
     }
   }
 }

--- a/plugin/test/unit/helpers/functions.spec.ts
+++ b/plugin/test/unit/helpers/functions.spec.ts
@@ -6,7 +6,7 @@ import Chance from 'chance'
 import { copy, existsSync } from 'fs-extra'
 import { dir as getTmpDir } from 'tmp-promise'
 
-import { setupImageCdn } from '../../../src/helpers/functions'
+import { writeFunctions } from '../../../src/helpers/functions'
 
 const SAMPLE_PROJECT_DIR = `${__dirname}/../../../../demo`
 const TEST_TIMEOUT = 60_000
@@ -26,7 +26,7 @@ const moveGatsbyDir = async () => {
 
 const chance = new Chance()
 
-describe('setupImageCdn', () => {
+describe('writeFunctions', () => {
   let cleanup
   let restoreCwd
 
@@ -85,7 +85,11 @@ describe('setupImageCdn', () => {
         },
       }
 
-      await setupImageCdn({ constants, netlifyConfig })
+      await writeFunctions({
+        constants,
+        netlifyConfig,
+        neededFunctions: [],
+      })
 
       const doesDirectoryExist = existsSync(
         join(process.cwd(), 'demo', '.netlify', 'functions-internal'),


### PR DESCRIPTION
### Summary

If image cdn is enabled:

1. If IPX is used: encrypt remote urls if used gatsby packages version support it
2. If Netlify Image CDN is used: apply allowed remote url patterns for file CDN

Additionally only setup required url patterns by used gatsby packages versions