### PR TITLE
ci: unpin cli version in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           key:
             ubuntu-build-${{ env.cache-name }}-${{
             hashFiles('plugin/test/fixtures/**/package.json') }}-node-modules
-      - run: npm install -g netlify-cli@18.0.0
+      - run: npm install -g netlify-cli
       - run: npm ci
       - run: cd plugin && npm ci && npm run build
       - run: npm test
@@ -56,7 +56,7 @@ jobs:
           key:
             macOS-build-${{ env.cache-name }}-${{
             hashFiles('plugin/test/fixtures/**/package.json') }}-node-modules
-      - run: npm install -g netlify-cli@18.0.0
+      - run: npm install -g netlify-cli
       - run: npm ci
       - run: cd plugin && npm ci && npm run build
       - run: npm test


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/frameworks as the Reviewer -->

### Summary

Leverage the latest cli in the test workflow

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was
published correctly.
